### PR TITLE
Fix edit mode buttons displaying no text

### DIFF
--- a/game_core/edit_mode/buttons.py
+++ b/game_core/edit_mode/buttons.py
@@ -40,6 +40,8 @@ class Button:
     def update(self, mouse_pos):
         """Update button state based on mouse position"""
         self.is_hovered = self.rect.collidepoint(mouse_pos)
+        # Keep the text centered if the button position changes
+        self.text_rect = self.text_surf.get_rect(center=self.rect.center)
 
     def draw(self, surface):
         """Draw the button on the given surface"""


### PR DESCRIPTION
## Summary
- ensure text gets recentered for edit mode buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68409e335140832d897a4de7b632d388