### PR TITLE
Add color palette for edit mode buttons

### DIFF
--- a/game_core/edit_mode/buttons.py
+++ b/game_core/edit_mode/buttons.py
@@ -4,6 +4,7 @@ import pygame
 
 from game_core.other_components.config import *
 from game_core.other_components.font_loader import font_loader
+from .color_palette import EASY_GREEN, EASY_GREEN_HOVER, BORDER_GRAY
 
 
 class Button:
@@ -30,9 +31,9 @@ class Button:
         self.rect = pygame.Rect(x, y, width, height)
         self.text_rect = self.text_surf.get_rect(center=self.rect.center)
 
-        self.bg_color = (80, 80, 80)
-        self.hover_color = (110, 110, 110)
-        self.border_color = (200, 200, 200)
+        self.bg_color = EASY_GREEN
+        self.hover_color = EASY_GREEN_HOVER
+        self.border_color = BORDER_GRAY
         self.is_hovered = False
         self.image = None
         self.hover_image = None

--- a/game_core/edit_mode/color_palette/__init__.py
+++ b/game_core/edit_mode/color_palette/__init__.py
@@ -1,0 +1,5 @@
+"""Color palette for the edit mode UI."""
+
+from .colors import *
+
+__all__ = [name for name in globals() if name.isupper()]

--- a/game_core/edit_mode/color_palette/colors.py
+++ b/game_core/edit_mode/color_palette/colors.py
@@ -1,0 +1,8 @@
+"""Custom colors used in the edit mode UI."""
+
+# Main color - a soft green that is easy on the eyes
+EASY_GREEN = (96, 180, 96)
+# Slightly brighter shade for hover states
+EASY_GREEN_HOVER = (116, 200, 116)
+# Neutral border color used around buttons
+BORDER_GRAY = (210, 210, 210)


### PR DESCRIPTION
## Summary
- add `color_palette` package inside edit mode
- define easy-on-the-eyes green shades
- use palette colors for code-based edit mode buttons

## Testing
- `python -m py_compile game_core/edit_mode/buttons.py game_core/edit_mode/color_palette/colors.py game_core/edit_mode/color_palette/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68409fd03140832da57d1dbe3b86e918