### PR TITLE
Add color mapping for edit mode buttons

### DIFF
--- a/game_core/edit_mode/buttons.py
+++ b/game_core/edit_mode/buttons.py
@@ -4,7 +4,17 @@ import pygame
 
 from game_core.other_components.config import *
 from game_core.other_components.font_loader import font_loader
-from .color_palette import EASY_GREEN, EASY_GREEN_HOVER, BORDER_GRAY
+from .color_palette import (
+    EASY_GREEN,
+    EASY_GREEN_HOVER,
+    BORDER_GRAY,
+    DELETE_RED,
+    DELETE_RED_HOVER,
+    CANCEL_GRAY,
+    CANCEL_GRAY_HOVER,
+    SAVE_BLUE,
+    SAVE_BLUE_HOVER,
+)
 
 
 class Button:
@@ -21,6 +31,7 @@ class Button:
         }
 
         self.text = text_lookup.get(button_type.lower(), button_type.title())
+        normalized_type = button_type.lower()
 
         font_size = int(FONT_SIZE_MEDIUM * scale)
         self.font = font_loader.get_font("medium", font_size)
@@ -31,8 +42,15 @@ class Button:
         self.rect = pygame.Rect(x, y, width, height)
         self.text_rect = self.text_surf.get_rect(center=self.rect.center)
 
-        self.bg_color = EASY_GREEN
-        self.hover_color = EASY_GREEN_HOVER
+        color_map = {
+            "delete": (DELETE_RED, DELETE_RED_HOVER),
+            "cancel": (CANCEL_GRAY, CANCEL_GRAY_HOVER),
+            "save": (SAVE_BLUE, SAVE_BLUE_HOVER),
+        }
+
+        self.bg_color, self.hover_color = color_map.get(
+            normalized_type, (EASY_GREEN, EASY_GREEN_HOVER)
+        )
         self.border_color = BORDER_GRAY
         self.is_hovered = False
         self.image = None

--- a/game_core/edit_mode/color_palette/colors.py
+++ b/game_core/edit_mode/color_palette/colors.py
@@ -6,3 +6,16 @@ EASY_GREEN = (96, 180, 96)
 EASY_GREEN_HOVER = (116, 200, 116)
 # Neutral border color used around buttons
 BORDER_GRAY = (210, 210, 210)
+
+# Additional colors for specific button types
+# Red shades for delete actions
+DELETE_RED = (200, 80, 80)
+DELETE_RED_HOVER = (220, 100, 100)
+
+# Gray shades for cancel actions
+CANCEL_GRAY = (160, 160, 160)
+CANCEL_GRAY_HOVER = (180, 180, 180)
+
+# Blue shades for save actions
+SAVE_BLUE = (80, 160, 220)
+SAVE_BLUE_HOVER = (100, 180, 240)


### PR DESCRIPTION
## Summary
- define new colors in the palette for delete, cancel and save buttons
- give `Button` class logic to use these colors based on button type

## Testing
- `python -m py_compile game_core/edit_mode/buttons.py`
- `python -m py_compile game_core/edit_mode/color_palette/colors.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840a1366e90832dac04e94d737e0755