### PR TITLE
Add modular sidebar and grid canvas

### DIFF
--- a/editor_app.py
+++ b/editor_app.py
@@ -13,7 +13,10 @@ from game_core.editor.config import (
     BACKGROUND_COLOR,
     FONT_PATH,
     FONT_COLOR,
+    maintain_aspect_ratio,
 )
+from game_core.editor.sidebar import Sidebar, SIDEBAR_WIDTH
+from game_core.editor.canvas import Canvas
 
 
 class EditorApp:
@@ -33,20 +36,28 @@ class EditorApp:
         self.title_surf = self.font.render("Edit Mode", True, FONT_COLOR)
         self.title_rect = self.title_surf.get_rect(center=(self.width // 2, self.height // 2))
 
+        # Editor UI components
+        self.sidebar = Sidebar(self.height, self.width - SIDEBAR_WIDTH)
+        self.canvas = Canvas(self.width - SIDEBAR_WIDTH, self.height)
+
     def handle_events(self):
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 self.running = False
             elif event.type == pygame.VIDEORESIZE:
-                self.width, self.height = event.size
+                self.width, self.height = maintain_aspect_ratio(*event.size)
                 self.screen = pygame.display.set_mode((self.width, self.height), pygame.RESIZABLE)
                 self.title_rect = self.title_surf.get_rect(center=(self.width // 2, self.height // 2))
+                self.sidebar.resize(self.height, self.width - SIDEBAR_WIDTH)
+                self.canvas.resize(self.width - SIDEBAR_WIDTH, self.height)
 
     def update(self):
         pass
 
     def draw(self):
         self.screen.fill(BACKGROUND_COLOR)
+        self.canvas.draw(self.screen)
+        self.sidebar.draw(self.screen)
         self.screen.blit(self.title_surf, self.title_rect)
         pygame.display.flip()
 

--- a/game_core/editor/canvas/__init__.py
+++ b/game_core/editor/canvas/__init__.py
@@ -1,0 +1,5 @@
+"""Canvas module exports."""
+
+from .canvas import Canvas
+
+__all__ = ["Canvas"]

--- a/game_core/editor/canvas/canvas.py
+++ b/game_core/editor/canvas/canvas.py
@@ -1,0 +1,31 @@
+"""Canvas component for the map editor."""
+
+from __future__ import annotations
+
+import pygame
+
+from ..color_palette import LIGHT_GRAY, DARK_GRAY
+
+
+class Canvas:
+    """Editable canvas with a fixed-size grid."""
+
+    def __init__(self, width: int, height: int, grid_size: int = 16, x: int = 0, y: int = 0) -> None:
+        self.grid_size = grid_size
+        self.rect = pygame.Rect(x, y, width, height)
+
+    def resize(self, width: int, height: int, x: int = 0, y: int = 0) -> None:
+        """Resize and reposition the canvas."""
+        self.rect.update(x, y, width, height)
+
+    def draw(self, surface: pygame.Surface) -> None:
+        """Draw the canvas background and grid."""
+        pygame.draw.rect(surface, DARK_GRAY, self.rect)
+
+        # Draw vertical grid lines
+        for gx in range(self.rect.left, self.rect.right, self.grid_size):
+            pygame.draw.line(surface, LIGHT_GRAY, (gx, self.rect.top), (gx, self.rect.bottom))
+
+        # Draw horizontal grid lines
+        for gy in range(self.rect.top, self.rect.bottom, self.grid_size):
+            pygame.draw.line(surface, LIGHT_GRAY, (self.rect.left, gy), (self.rect.right, gy))

--- a/game_core/editor/sidebar/sidebar.py
+++ b/game_core/editor/sidebar/sidebar.py
@@ -11,10 +11,15 @@ SIDEBAR_WIDTH = 500
 class Sidebar:
     """Simple vertical sidebar container."""
 
-    def __init__(self, height: int, x: int = 0):
+    def __init__(self, height: int, x: int = 0) -> None:
         self.width = SIDEBAR_WIDTH
         self.height = height
         self.rect = pygame.Rect(x, 0, self.width, self.height)
+
+    def resize(self, height: int, x: int) -> None:
+        """Resize and reposition the sidebar."""
+        self.height = height
+        self.rect.update(x, 0, self.width, self.height)
 
     def draw(self, surface: pygame.Surface) -> None:
         """Draw the sidebar on the given surface."""


### PR DESCRIPTION
## Summary
- make `Sidebar` resizable and integrate it into the editor
- create modular `Canvas` component with 16x16 grid
- display new canvas and sidebar in `EditorApp`

## Testing
- `python -m py_compile editor_app.py game_core/editor/sidebar/sidebar.py game_core/editor/canvas/canvas.py`


------
https://chatgpt.com/codex/tasks/task_e_6841e816bbf0832dac415c79a6d31942