### PR TITLE
Add fullscreen and tab tabs for editor

### DIFF
--- a/editor_app.py
+++ b/editor_app.py
@@ -15,6 +15,7 @@ from game_core.editor.config import (
 )
 from game_core.editor.sidebar import Sidebar, SIDEBAR_WIDTH
 from game_core.editor.canvas import Canvas
+from game_core.editor.tab_manager import TabManager
 
 
 class EditorApp:
@@ -28,12 +29,28 @@ class EditorApp:
         self.running = True
         self.width = WIDTH
         self.height = HEIGHT
+        self.fullscreen = False
 
 
 
         # Editor UI components
         self.sidebar = Sidebar(self.height, self.width - SIDEBAR_WIDTH)
         self.canvas = Canvas(self.width - SIDEBAR_WIDTH, self.height)
+        self.tab_manager = TabManager(["tiles", "browse", "save"], self.sidebar.rect)
+
+    def toggle_fullscreen(self) -> None:
+        """Toggle fullscreen mode."""
+        self.fullscreen = not self.fullscreen
+        if self.fullscreen:
+            info = pygame.display.Info()
+            self.width, self.height = info.current_w, info.current_h
+            self.screen = pygame.display.set_mode((self.width, self.height), pygame.FULLSCREEN)
+        else:
+            self.width, self.height = WIDTH, HEIGHT
+            self.screen = pygame.display.set_mode((self.width, self.height), pygame.RESIZABLE)
+        self.sidebar.resize(self.height, self.width - SIDEBAR_WIDTH)
+        self.canvas.resize(self.width - SIDEBAR_WIDTH, self.height)
+        self.tab_manager.resize(self.sidebar.rect)
 
     def handle_events(self):
         for event in pygame.event.get():
@@ -44,6 +61,10 @@ class EditorApp:
                 self.screen = pygame.display.set_mode((self.width, self.height), pygame.RESIZABLE)
                 self.sidebar.resize(self.height, self.width - SIDEBAR_WIDTH)
                 self.canvas.resize(self.width - SIDEBAR_WIDTH, self.height)
+                self.tab_manager.resize(self.sidebar.rect)
+            elif event.type == pygame.KEYDOWN and event.key == pygame.K_F11:
+                self.toggle_fullscreen()
+            self.tab_manager.handle_event(event)
 
     def update(self):
         pass
@@ -52,6 +73,7 @@ class EditorApp:
         self.screen.fill(BACKGROUND_COLOR)
         self.canvas.draw(self.screen)
         self.sidebar.draw(self.screen)
+        self.tab_manager.draw(self.screen)
         pygame.display.flip()
 
     def run(self):

--- a/game_core/editor/__init__.py
+++ b/game_core/editor/__init__.py
@@ -1,3 +1,7 @@
 """Editor package containing editor-specific modules."""
 
-__all__ = []
+__all__ = ["Sidebar", "Canvas", "TabManager"]
+
+from .sidebar import Sidebar
+from .canvas import Canvas
+from .tab_manager import TabManager

--- a/game_core/editor/tab_manager.py
+++ b/game_core/editor/tab_manager.py
@@ -1,0 +1,59 @@
+"""Simple tab manager for sidebar tabs."""
+
+from __future__ import annotations
+
+import pygame
+
+from .color_palette import LIGHT_GRAY, DARK_GRAY, SIDEBAR_BORDER, WHITE
+from .config import FONT_PATH
+
+
+class TabManager:
+    """Manage a list of tabs displayed inside a sidebar."""
+
+    TAB_HEIGHT = 30
+    TAB_WIDTH = 100
+    PADDING = 5
+
+    def __init__(self, tabs: list[str], sidebar_rect: pygame.Rect) -> None:
+        self.tabs = tabs
+        self.active = 0
+        self.sidebar_rect = sidebar_rect
+        self.font = pygame.font.Font(FONT_PATH, 16)
+
+    def resize(self, sidebar_rect: pygame.Rect) -> None:
+        """Update the sidebar reference when resized."""
+        self.sidebar_rect = sidebar_rect
+
+    def handle_event(self, event: pygame.event.Event) -> None:
+        """Handle mouse clicks to switch tabs."""
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            mx, my = event.pos
+            for index, rect in enumerate(self._tab_rects()):
+                if rect.collidepoint(mx, my):
+                    self.active = index
+                    break
+
+    def _tab_rects(self) -> list[pygame.Rect]:
+        rects = []
+        x = self.sidebar_rect.left + self.PADDING
+        y = self.sidebar_rect.top + self.PADDING
+        for _ in self.tabs:
+            rect = pygame.Rect(x, y, self.TAB_WIDTH, self.TAB_HEIGHT)
+            rects.append(rect)
+            x += self.TAB_WIDTH + self.PADDING
+        return rects
+
+    def draw(self, surface: pygame.Surface) -> None:
+        """Draw the tab bar onto the surface."""
+        for index, rect in enumerate(self._tab_rects()):
+            if index == self.active:
+                color = LIGHT_GRAY
+            else:
+                color = DARK_GRAY
+            pygame.draw.rect(surface, color, rect)
+            pygame.draw.rect(surface, SIDEBAR_BORDER, rect, 1)
+
+            label = self.font.render(self.tabs[index].title(), True, WHITE)
+            label_rect = label.get_rect(center=rect.center)
+            surface.blit(label, label_rect)


### PR DESCRIPTION
## Summary
- support fullscreen toggle in `editor_app.py`
- implement `TabManager` for sidebar tabs
- expose new class from editor package

## Testing
- `python -m py_compile editor_app.py game_core/editor/tab_manager.py game_core/editor/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6841ec6bd62c832d94312c885313021c