### PR TITLE
Refactor tileset tab layout

### DIFF
--- a/game_core/editor/__init__.py
+++ b/game_core/editor/__init__.py
@@ -1,7 +1,8 @@
 """Editor package containing editor-specific modules."""
 
-__all__ = ["Sidebar", "Canvas", "TabManager"]
+__all__ = ["Sidebar", "Canvas", "TabManager", "TilesetTabManager"]
 
 from .sidebar import Sidebar
 from .canvas import Canvas
 from .tab_manager import TabManager
+from .tileset_tab.tileset_tab_manager import TilesetTabManager

--- a/game_core/editor/tileset_tab/tileset_tab_manager.py
+++ b/game_core/editor/tileset_tab/tileset_tab_manager.py
@@ -1,0 +1,57 @@
+"""Tab manager for selecting tilesets within the tiles tab."""
+
+from __future__ import annotations
+
+import pygame
+
+from ..color_palette import LIGHT_GRAY, DARK_GRAY, SIDEBAR_BORDER, WHITE
+from ..config import FONT_PATH
+
+
+class TilesetTabManager:
+    """Manage numeric tileset tabs (1-6) inside the tiles tab."""
+
+    TAB_HEIGHT = 30
+    TAB_WIDTH = 40
+    PADDING = 5
+
+    def __init__(self, sidebar_rect: pygame.Rect) -> None:
+        self.sidebar_rect = sidebar_rect
+        self.font = pygame.font.Font(FONT_PATH, 16)
+
+        self.tilesets = [str(i) for i in range(1, 7)]
+        self.active = 0
+
+    def resize(self, sidebar_rect: pygame.Rect) -> None:
+        """Update position and size when the sidebar changes."""
+        self.sidebar_rect = sidebar_rect
+
+    def handle_event(self, event: pygame.event.Event) -> None:
+        """Handle mouse clicks to switch tilesets."""
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            mx, my = event.pos
+            for index, rect in enumerate(self._tileset_rects()):
+                if rect.collidepoint(mx, my):
+                    self.active = index
+                    break
+
+    def _tileset_rects(self) -> list[pygame.Rect]:
+        rects = []
+        x = self.sidebar_rect.left + self.PADDING
+        y = self.sidebar_rect.top + self.PADDING * 2 + self.TAB_HEIGHT
+        for _ in self.tilesets:
+            rect = pygame.Rect(x, y, self.TAB_WIDTH, self.TAB_HEIGHT)
+            rects.append(rect)
+            x += self.TAB_WIDTH + self.PADDING
+        return rects
+
+    def draw(self, surface: pygame.Surface) -> None:
+        """Draw tileset tabs on the given surface."""
+        for index, rect in enumerate(self._tileset_rects()):
+            color = LIGHT_GRAY if index == self.active else DARK_GRAY
+            pygame.draw.rect(surface, color, rect)
+            pygame.draw.rect(surface, SIDEBAR_BORDER, rect, 1)
+
+            label = self.font.render(self.tilesets[index], True, WHITE)
+            label_rect = label.get_rect(center=rect.center)
+            surface.blit(label, label_rect)


### PR DESCRIPTION
## Summary
- size tileset tabs smaller and lay them out horizontally

## Testing
- `python -m py_compile editor_app.py gameplay_app.py game_core/editor/*.py game_core/editor/*/*.py game_core/editor/tileset_tab/tileset_tab_manager.py`
- `import editor_app` *(fails: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_6841f423f094832db0fceb581582a1ce