### PR TITLE
Add tileset helper modules

### DIFF
--- a/game_core/editor/tileset_tab/tilesets/overworld_anim_tilesets/Overworld_ani_tiles.py
+++ b/game_core/editor/tileset_tab/tilesets/overworld_anim_tilesets/Overworld_ani_tiles.py
@@ -1,0 +1,25 @@
+"""Helpers for the animated overworld water tileset."""
+
+import os
+from typing import List
+import pygame
+
+# Base directory for the animated tiles
+TILESET_DIR = os.path.join("Tilesets", "Overworld_ani_tiles")
+
+# Preview image paths for palette representation
+PALETTE_TILES = [
+    os.path.join(TILESET_DIR, "edge_water_tile", "tile000.png"),
+    os.path.join(TILESET_DIR, "regia_waterplant_tile", "tile000.png"),
+    os.path.join(TILESET_DIR, "water_tile", "tile000.png"),
+    os.path.join(TILESET_DIR, "waterplant_tile", "tile000.png"),
+]
+
+
+def load_preview_tiles() -> List[pygame.Surface]:
+    """Load preview frames for the animated tiles."""
+    previews: List[pygame.Surface] = []
+    for path in PALETTE_TILES:
+        if os.path.exists(path):
+            previews.append(pygame.image.load(path).convert_alpha())
+    return previews

--- a/game_core/editor/tileset_tab/tilesets/overworld_tilesets/overworld_tileset.py
+++ b/game_core/editor/tileset_tab/tilesets/overworld_tilesets/overworld_tileset.py
@@ -1,0 +1,28 @@
+"""Utility helpers for the main overworld tileset."""
+
+import os
+from typing import List, Optional
+import pygame
+
+# Folder containing individual tile images
+TILESET_DIR = os.path.join("Tilesets", "Overworld")
+
+# Dimensions of the palette image (width, height)
+PALETTE_SIZE = (288, 208)
+
+# Path to the palette image showing all overworld tiles
+PALETTE_IMAGE = os.path.join("Tilesets", "Overworld_Tileset.png")
+
+
+def load_palette() -> Optional[pygame.Surface]:
+    """Load the overworld palette image if available."""
+    if os.path.exists(PALETTE_IMAGE):
+        return pygame.image.load(PALETTE_IMAGE).convert_alpha()
+    return None
+
+
+def tile_paths() -> List[str]:
+    """Return sorted file paths for all overworld tile images."""
+    files = [f for f in os.listdir(TILESET_DIR) if f.endswith(".png")]
+    files.sort()
+    return [os.path.join(TILESET_DIR, f) for f in files]


### PR DESCRIPTION
## Summary
- drop previous JSON palette configuration
- add python helpers for overworld and animated water tilesets
- move helper modules inside the editor's tileset folder

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841f8b02290832dbd8cf5e4fa09ea9b