### PR TITLE
Add overworld palette to tiles tab

### DIFF
--- a/game_core/editor/tab_manager.py
+++ b/game_core/editor/tab_manager.py
@@ -7,6 +7,7 @@ import pygame
 from .color_palette import LIGHT_GRAY, DARK_GRAY, SIDEBAR_BORDER, WHITE
 from .config import FONT_PATH
 from .tileset_tab.tileset_tab_manager import TilesetTabManager
+from .tileset_tab.tilesets.overworld_tileset import OverworldTileset
 
 
 class TabManager:
@@ -24,6 +25,11 @@ class TabManager:
 
         # Manager for the numeric tileset tabs
         self.tileset_manager = TilesetTabManager(sidebar_rect)
+
+        # Panels corresponding to each tileset index
+        self.tileset_panels: dict[int, object] = {
+            0: OverworldTileset(),
+        }
 
     @property
     def active_tileset(self) -> int:
@@ -71,5 +77,8 @@ class TabManager:
 
         if self.tabs[self.active] == "tiles":
             self.tileset_manager.draw(surface)
+            panel = self.tileset_panels.get(self.tileset_manager.active)
+            if panel:
+                panel.draw(surface, self.sidebar_rect)
 
 

--- a/game_core/editor/tileset_tab/tilesets/overworld_tileset.py
+++ b/game_core/editor/tileset_tab/tilesets/overworld_tileset.py
@@ -1,0 +1,55 @@
+"""Utilities for loading the overworld tileset panel."""
+
+import os
+from typing import List, Optional
+import pygame
+
+from ..tileset_tab_manager import TilesetTabManager
+
+# Directory containing the overworld tiles
+TILESET_DIR = os.path.join("Tilesets", "Overworld")
+
+# Dimensions of the overworld palette image
+PALETTE_SIZE = (288, 208)
+
+# Path to the preview palette image
+PALETTE_IMAGE = os.path.join("Tilesets", "Overworld_Tileset.png")
+
+
+def load_palette() -> Optional[pygame.Surface]:
+    """Load the overworld palette image if available."""
+    if os.path.exists(PALETTE_IMAGE):
+        return pygame.image.load(PALETTE_IMAGE).convert_alpha()
+    return None
+
+
+def tile_paths() -> List[str]:
+    """Return sorted file paths for individual overworld tile images."""
+    files = [f for f in os.listdir(TILESET_DIR) if f.endswith(".png")]
+    files.sort()
+    return [os.path.join(TILESET_DIR, f) for f in files]
+
+
+class OverworldTileset:
+    """Panel displaying the overworld tileset palette."""
+
+    def __init__(self) -> None:
+        self.palette = load_palette()
+        self.rect = pygame.Rect(0, 0, *PALETTE_SIZE)
+
+    def draw(self, surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
+        """Blit the palette image inside the sidebar when available."""
+        if not self.palette:
+            return
+
+        padding = TilesetTabManager.PADDING
+        y_offset = (
+            padding * 3
+            + TilesetTabManager.TAB_HEIGHT
+            + TilesetTabManager.TAB_HEIGHT
+        )
+        self.rect.topleft = (
+            sidebar_rect.left + padding,
+            sidebar_rect.top + y_offset,
+        )
+        surface.blit(self.palette, self.rect.topleft)


### PR DESCRIPTION
## Summary
- show Overworld palette when numeric tab 1 is active
- define `OverworldTileset` panel class

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6841fdda6d60832dadbc02d7abd5816e