### PR TITLE
Add Overworld tileset loader

### DIFF
--- a/game_core/editor/tileset_tab/tileset_components/__init__.py
+++ b/game_core/editor/tileset_tab/tileset_components/__init__.py
@@ -1,0 +1,5 @@
+"""Tileset component exports."""
+
+from .overworld_tileset import OverworldTileset
+
+__all__ = ["OverworldTileset"]

--- a/game_core/editor/tileset_tab/tileset_components/overworld_tileset.py
+++ b/game_core/editor/tileset_tab/tileset_components/overworld_tileset.py
@@ -1,0 +1,43 @@
+"""Loader for the overworld tileset palette."""
+
+from __future__ import annotations
+
+import os
+import pygame
+
+from game_core.gameplay.other_components.image_cache import sprite_cache
+
+
+class OverworldTileset:
+    """Load and store overworld tiles for the editor palette."""
+
+    TILE_SIZE = 16
+
+    def __init__(self, tileset_folder: str = "Tilesets/Overworld") -> None:
+        self.tileset_folder = tileset_folder
+        self.tiles: list[pygame.Surface] = []
+        self.load_tiles()
+
+    def load_tiles(self) -> None:
+        """Load all tile images from the overworld folder."""
+        if not os.path.isdir(self.tileset_folder):
+            return
+
+        png_files = [f for f in os.listdir(self.tileset_folder) if f.endswith('.png')]
+        png_files.sort()
+
+        for filename in png_files:
+            path = os.path.join(self.tileset_folder, filename)
+            sprite = sprite_cache.get_sprite(path)
+            if sprite is not None:
+                self.tiles.append(sprite)
+
+    def get_tile(self, index: int) -> pygame.Surface | None:
+        """Return the tile surface at the specified index."""
+        if 0 <= index < len(self.tiles):
+            return self.tiles[index]
+        return None
+
+    def tile_count(self) -> int:
+        """Return the number of loaded tiles."""
+        return len(self.tiles)


### PR DESCRIPTION
## Summary
- add a new tileset_components package
- implement `OverworldTileset` to load tiles from `Tilesets/Overworld`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684262d581b8832da036b87eb8530b51