### PR TITLE
Display overworld tileset in editor

### DIFF
--- a/game_core/editor/sidebar_tab_manager.py
+++ b/game_core/editor/sidebar_tab_manager.py
@@ -7,6 +7,7 @@ import pygame
 from .color_palette import LIGHT_GRAY, DARK_GRAY, SIDEBAR_BORDER, WHITE
 from .config import FONT_PATH
 from .tileset_tab.tileset_tab_manager import TilesetTabManager
+from .tileset_tab.show_tileset import draw_tileset
 
 
 class TabManager:
@@ -71,5 +72,6 @@ class TabManager:
 
         if self.tabs[self.active] == "tiles":
             self.tileset_manager.draw(surface)
+            draw_tileset(surface, self.tileset_manager.active, self.sidebar_rect)
 
 

--- a/game_core/editor/tileset_tab/show_tileset.py
+++ b/game_core/editor/tileset_tab/show_tileset.py
@@ -1,3 +1,47 @@
 """Utilities for displaying tilesets in the editor."""
 
+from __future__ import annotations
 
+from typing import Optional
+import pygame
+
+from .tileset_components import OverworldTileset
+from .tileset_tab_manager import TilesetTabManager
+
+# Lazy loaded tileset instances
+_overworld_tileset: Optional[OverworldTileset] = None
+
+
+def _get_overworld_tileset() -> OverworldTileset:
+    """Return the singleton overworld tileset, loading it if needed."""
+    global _overworld_tileset
+    if _overworld_tileset is None:
+        _overworld_tileset = OverworldTileset()
+    return _overworld_tileset
+
+
+def draw_tileset(surface: pygame.Surface, index: int, sidebar_rect: pygame.Rect) -> None:
+    """Draw the tileset corresponding to ``index`` inside the sidebar."""
+    if index != 0:
+        # Only overworld tileset is currently implemented
+        return
+
+    tileset = _get_overworld_tileset()
+
+    scale = 2
+    spacing = 2
+    tile_size = tileset.TILE_SIZE
+    scaled_size = tile_size * scale
+
+    tiles_per_row = max(1, (sidebar_rect.width - spacing * 2) // (scaled_size + spacing))
+    start_x = sidebar_rect.left + spacing
+    start_y = sidebar_rect.top + TilesetTabManager.PADDING * 3 + TilesetTabManager.TAB_HEIGHT * 2
+
+    for i in range(tileset.tile_count()):
+        tile = tileset.get_tile(i)
+        if tile is None:
+            continue
+        dest_x = start_x + (i % tiles_per_row) * (scaled_size + spacing)
+        dest_y = start_y + (i // tiles_per_row) * (scaled_size + spacing)
+        scaled = pygame.transform.scale(tile, (scaled_size, scaled_size))
+        surface.blit(scaled, (dest_x, dest_y))


### PR DESCRIPTION
## Summary
- draw overworld tileset in the sidebar
- include drawing logic in the tab manager

## Testing
- `python -m py_compile game_core/editor/sidebar_tab_manager.py game_core/editor/tileset_tab/show_tileset.py`
- `python -m py_compile editor_app.py`

------
https://chatgpt.com/codex/tasks/task_e_684264f0b3ac832d82f04226e2cb6ae6