### PR TITLE
Display overworld tileset at native size

### DIFF
--- a/game_core/editor/tileset_tab/show_tileset.py
+++ b/game_core/editor/tileset_tab/show_tileset.py
@@ -28,12 +28,15 @@ def draw_tileset(surface: pygame.Surface, index: int, sidebar_rect: pygame.Rect)
 
     tileset = _get_overworld_tileset()
 
-    scale = 2
-    spacing = 2
+    # Draw tiles at their original 16x16 resolution so the entire tileset
+    # (288x208) fits within the sidebar without scrolling.
+    scale = 1
+    spacing = 0
     tile_size = tileset.TILE_SIZE
     scaled_size = tile_size * scale
 
-    tiles_per_row = max(1, (sidebar_rect.width - spacing * 2) // (scaled_size + spacing))
+    # Arrange tiles in the original grid layout
+    tiles_per_row = tileset.tiles_per_row()
     start_x = sidebar_rect.left + spacing
     start_y = sidebar_rect.top + TilesetTabManager.PADDING * 3 + TilesetTabManager.TAB_HEIGHT * 2
 

--- a/game_core/editor/tileset_tab/tileset_components/overworld_tileset.py
+++ b/game_core/editor/tileset_tab/tileset_components/overworld_tileset.py
@@ -12,11 +12,18 @@ class OverworldTileset:
     """Load and store overworld tiles for the editor palette."""
 
     TILE_SIZE = 16
+    # Dimensions of the full overworld tileset image (in pixels)
+    TILESET_WIDTH = 288
+    TILESET_HEIGHT = 208
 
     def __init__(self, tileset_folder: str = "Tilesets/Overworld") -> None:
         self.tileset_folder = tileset_folder
         self.tiles: list[pygame.Surface] = []
         self.load_tiles()
+
+    def tiles_per_row(self) -> int:
+        """Return the number of tiles per row in the full tileset image."""
+        return self.TILESET_WIDTH // self.TILE_SIZE
 
     def load_tiles(self) -> None:
         """Load all tile images from the overworld folder."""


### PR DESCRIPTION
## Summary
- expose overworld tileset dimensions
- show tiles at 16x16 in the editor sidebar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842666ca31c832dafa995441975cc3a