### PR TITLE
Display overworld tileset at auto scale

### DIFF
--- a/game_core/editor/sidebar_tab_manager.py
+++ b/game_core/editor/sidebar_tab_manager.py
@@ -7,7 +7,7 @@ import pygame
 from .color_palette import LIGHT_GRAY, DARK_GRAY, SIDEBAR_BORDER, WHITE
 from .config import FONT_PATH
 from .tileset_tab.tileset_tab_manager import TilesetTabManager
-from .tileset_tab.show_tileset import draw_tileset
+from .tileset_tab.show_overworld_tileset import draw_tileset
 
 
 class TabManager:

--- a/game_core/editor/tileset_tab/show_overworld_tileset.py
+++ b/game_core/editor/tileset_tab/show_overworld_tileset.py
@@ -1,8 +1,9 @@
-"""Utilities for displaying tilesets in the editor."""
+"""Utilities for displaying the overworld tileset in the editor."""
 
 from __future__ import annotations
 
 from typing import Optional
+import math
 import pygame
 
 from .tileset_components import OverworldTileset
@@ -28,15 +29,33 @@ def draw_tileset(surface: pygame.Surface, index: int, sidebar_rect: pygame.Rect)
 
     tileset = _get_overworld_tileset()
 
-    scale = 2
+    # Automatically scale the overworld tileset to fit inside the sidebar.
     spacing = 2
     tile_size = tileset.TILE_SIZE
-    scaled_size = tile_size * scale
 
-    tiles_per_row = max(1, (sidebar_rect.width - spacing * 2) // (scaled_size + spacing))
+    tiles_per_row = tileset.tiles_per_row()
+    rows = math.ceil(tileset.tile_count() / tiles_per_row)
+
     start_x = sidebar_rect.left + spacing
-    start_y = sidebar_rect.top + TilesetTabManager.PADDING * 3 + TilesetTabManager.TAB_HEIGHT * 2
+    start_y = (
+        sidebar_rect.top
+        + TilesetTabManager.PADDING * 3
+        + TilesetTabManager.TAB_HEIGHT * 2
+    )
 
+    avail_width = sidebar_rect.width - spacing * 2
+    avail_height = sidebar_rect.bottom - start_y - spacing
+
+    total_width = tile_size * tiles_per_row + spacing * (tiles_per_row - 1)
+    total_height = tile_size * rows + spacing * (rows - 1)
+
+    scale_x = avail_width / total_width
+    scale_y = avail_height / total_height
+    scale = min(scale_x, scale_y)
+
+    scaled_size = max(1, int(tile_size * scale))
+
+    # Arrange tiles in the original grid layout
     for i in range(tileset.tile_count()):
         tile = tileset.get_tile(i)
         if tile is None:

--- a/game_core/editor/tileset_tab/tileset_components/overworld_tileset.py
+++ b/game_core/editor/tileset_tab/tileset_components/overworld_tileset.py
@@ -12,11 +12,18 @@ class OverworldTileset:
     """Load and store overworld tiles for the editor palette."""
 
     TILE_SIZE = 16
+    # Dimensions of the full overworld tileset image (in pixels)
+    TILESET_WIDTH = 288
+    TILESET_HEIGHT = 208
 
     def __init__(self, tileset_folder: str = "Tilesets/Overworld") -> None:
         self.tileset_folder = tileset_folder
         self.tiles: list[pygame.Surface] = []
         self.load_tiles()
+
+    def tiles_per_row(self) -> int:
+        """Return the number of tiles per row in the full tileset image."""
+        return self.TILESET_WIDTH // self.TILE_SIZE
 
     def load_tiles(self) -> None:
         """Load all tile images from the overworld folder."""


### PR DESCRIPTION
## Summary
- rename `show_tileset.py` -> `show_overworld_tileset.py`
- automatically scale overworld tileset to fit inside the sidebar
- update TabManager import

## Testing
- `python -m py_compile game_core/editor/tileset_tab/show_overworld_tileset.py`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842666ca31c832dafa995441975cc3a