### PR TITLE
Add animated overworld tileset

### DIFF
--- a/game_core/editor/sidebar_tab_manager.py
+++ b/game_core/editor/sidebar_tab_manager.py
@@ -7,7 +7,6 @@ import pygame
 from .color_palette import LIGHT_GRAY, DARK_GRAY, SIDEBAR_BORDER, WHITE
 from .config import FONT_PATH
 from .tileset_tab.tileset_tab_manager import TilesetTabManager
-from .tileset_tab.show_overworld_tileset import draw_tileset
 
 
 class TabManager:
@@ -72,6 +71,5 @@ class TabManager:
 
         if self.tabs[self.active] == "tiles":
             self.tileset_manager.draw(surface)
-            draw_tileset(surface, self.tileset_manager.active, self.sidebar_rect)
 
 

--- a/game_core/editor/tileset_tab/show_overworld_anim_tileset.py
+++ b/game_core/editor/tileset_tab/show_overworld_anim_tileset.py
@@ -1,29 +1,29 @@
-"""Utilities for displaying tilesets in the editor."""
+"""Utilities for displaying the animated overworld tileset."""
 
 from __future__ import annotations
 
 from typing import Optional
 import pygame
 
-from .tileset_components import OverworldTileset
+from .tileset_components import OverworldAnimTileset
 from .tileset_tab_manager import TilesetTabManager
 
 # Lazy loaded tileset instances
-_overworld_tileset: Optional[OverworldTileset] = None
+_overworld_anim_tileset: Optional[OverworldAnimTileset] = None
 
 
-def _get_overworld_tileset() -> OverworldTileset:
-    """Return the singleton overworld tileset, loading it if needed."""
-    global _overworld_tileset
-    if _overworld_tileset is None:
-        _overworld_tileset = OverworldTileset()
-    return _overworld_tileset
+def _get_overworld_anim_tileset() -> OverworldAnimTileset:
+    """Return the singleton animated overworld tileset, loading it if needed."""
+    global _overworld_anim_tileset
+    if _overworld_anim_tileset is None:
+        _overworld_anim_tileset = OverworldAnimTileset()
+    return _overworld_anim_tileset
 
 
 def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
-    """Draw the overworld tileset inside the sidebar."""
+    """Draw the animated overworld tileset in the sidebar."""
 
-    tileset = _get_overworld_tileset()
+    tileset = _get_overworld_anim_tileset()
 
     # Scale tiles so the full tileset fits inside the sidebar.
     spacing = 2

--- a/game_core/editor/tileset_tab/tileset_tab_manager.py
+++ b/game_core/editor/tileset_tab/tileset_tab_manager.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import pygame
 
+from .show_overworld_tileset import draw_tileset as draw_overworld_tileset
+from .show_overworld_anim_tileset import draw_tileset as draw_overworld_anim_tileset
+
 from ..color_palette import LIGHT_GRAY, DARK_GRAY, SIDEBAR_BORDER, WHITE
 from ..config import FONT_PATH
 
@@ -21,6 +24,7 @@ class TilesetTabManager:
 
         self.tilesets = [str(i) for i in range(1, 7)]
         self.active = 0
+        self._drawers = [draw_overworld_tileset, draw_overworld_anim_tileset]
 
     def resize(self, sidebar_rect: pygame.Rect) -> None:
         """Update position and size when the sidebar changes."""
@@ -55,3 +59,7 @@ class TilesetTabManager:
             label = self.font.render(self.tilesets[index], True, WHITE)
             label_rect = label.get_rect(center=rect.center)
             surface.blit(label, label_rect)
+
+        if self.active < len(self._drawers):
+            drawer = self._drawers[self.active]
+            drawer(surface, self.sidebar_rect)


### PR DESCRIPTION
## Summary
- implement a new show file for the animated overworld tileset
- hook animated tileset into the sidebar tab logic
- **refactor**: move tileset drawing to TilesetTabManager

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68426fe3db88832d8f3083f4d037c654