### PR TITLE
Fix circular import in tileset modules

### DIFF
--- a/game_core/editor/tileset_tab/show_overworld_anim_tileset.py
+++ b/game_core/editor/tileset_tab/show_overworld_anim_tileset.py
@@ -6,7 +6,6 @@ from typing import Optional
 import pygame
 
 from .tileset_components import OverworldAnimTileset
-from .tileset_tab_manager import TilesetTabManager
 
 # Lazy loaded tileset instances
 _overworld_anim_tileset: Optional[OverworldAnimTileset] = None
@@ -22,6 +21,9 @@ def _get_overworld_anim_tileset() -> OverworldAnimTileset:
 
 def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
     """Draw the animated overworld tileset in the sidebar."""
+
+    # Import here to avoid circular dependency during module initialization
+    from .tileset_tab_manager import TilesetTabManager
 
     tileset = _get_overworld_anim_tileset()
 

--- a/game_core/editor/tileset_tab/show_overworld_tileset.py
+++ b/game_core/editor/tileset_tab/show_overworld_tileset.py
@@ -6,7 +6,6 @@ from typing import Optional
 import pygame
 
 from .tileset_components import OverworldTileset
-from .tileset_tab_manager import TilesetTabManager
 
 # Lazy loaded tileset instances
 _overworld_tileset: Optional[OverworldTileset] = None
@@ -22,6 +21,9 @@ def _get_overworld_tileset() -> OverworldTileset:
 
 def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
     """Draw the overworld tileset inside the sidebar."""
+
+    # Import here to avoid circular dependency during module initialization
+    from .tileset_tab_manager import TilesetTabManager
 
     tileset = _get_overworld_tileset()
 


### PR DESCRIPTION
## Summary
- avoid circular import by lazily importing `TilesetTabManager`

## Testing
- `python -m py_compile game_core/editor/tileset_tab/show_overworld_tileset.py`
- `python -m py_compile game_core/editor/tileset_tab/show_overworld_anim_tileset.py`


------
https://chatgpt.com/codex/tasks/task_e_6842733b2730832d81edc6bffdaa3c66