### PR TITLE
Add dungeon tileset and limit scale factor

### DIFF
--- a/game_core/editor/tileset_tab/show_dungeon_tileset.py
+++ b/game_core/editor/tileset_tab/show_dungeon_tileset.py
@@ -1,31 +1,31 @@
-"""Utilities for displaying the animated overworld tileset."""
+"""Utilities for displaying the dungeon tileset."""
 
 from __future__ import annotations
 
 from typing import Optional
 import pygame
 
-from .tileset_components import OverworldAnimTileset
+from .tileset_components import DungeonTileset
 
-# Lazy loaded tileset instances
-_overworld_anim_tileset: Optional[OverworldAnimTileset] = None
+# Lazy loaded tileset instance
+_dungeon_tileset: Optional[DungeonTileset] = None
 
 
-def _get_overworld_anim_tileset() -> OverworldAnimTileset:
-    """Return the singleton animated overworld tileset, loading it if needed."""
-    global _overworld_anim_tileset
-    if _overworld_anim_tileset is None:
-        _overworld_anim_tileset = OverworldAnimTileset()
-    return _overworld_anim_tileset
+def _get_dungeon_tileset() -> DungeonTileset:
+    """Return the singleton dungeon tileset, loading it if needed."""
+    global _dungeon_tileset
+    if _dungeon_tileset is None:
+        _dungeon_tileset = DungeonTileset()
+    return _dungeon_tileset
 
 
 def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
-    """Draw the animated overworld tileset in the sidebar."""
+    """Draw the dungeon tileset inside the sidebar."""
 
     # Import here to avoid circular dependency during module initialization
     from .tileset_tab_manager import TilesetTabManager
 
-    tileset = _get_overworld_anim_tileset()
+    tileset = _get_dungeon_tileset()
 
     # Scale tiles so the full tileset fits inside the sidebar.
     spacing = 2

--- a/game_core/editor/tileset_tab/show_overworld_tileset.py
+++ b/game_core/editor/tileset_tab/show_overworld_tileset.py
@@ -42,7 +42,7 @@ def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
     scale_w = (available_width - spacing * tiles_per_row) / (tile_size * tiles_per_row)
     scale_h = (available_height - spacing * (rows - 1)) / (tile_size * rows)
 
-    scale = min(scale_w, scale_h)
+    scale = min(scale_w, scale_h, 2)
     if scale <= 0:
         scale = 1
 

--- a/game_core/editor/tileset_tab/tileset_components/__init__.py
+++ b/game_core/editor/tileset_tab/tileset_components/__init__.py
@@ -2,5 +2,6 @@
 
 from .overworld_tileset import OverworldTileset
 from .overworld_anim_tileset import OverworldAnimTileset
+from .dungeon_tileset import DungeonTileset
 
-__all__ = ["OverworldTileset", "OverworldAnimTileset"]
+__all__ = ["OverworldTileset", "OverworldAnimTileset", "DungeonTileset"]

--- a/game_core/editor/tileset_tab/tileset_components/dungeon_tileset.py
+++ b/game_core/editor/tileset_tab/tileset_components/dungeon_tileset.py
@@ -1,0 +1,50 @@
+"""Loader for the dungeon tileset palette."""
+
+from __future__ import annotations
+
+import os
+import pygame
+
+from game_core.gameplay.other_components.image_cache import sprite_cache
+
+
+class DungeonTileset:
+    """Load and store dungeon tiles for the editor palette."""
+
+    TILE_SIZE = 16
+    # Dimensions of the full dungeon tileset image (in pixels)
+    TILESET_WIDTH = 192
+    TILESET_HEIGHT = 208
+
+    def __init__(self, tileset_folder: str = "Tilesets/Dungeon") -> None:
+        self.tileset_folder = tileset_folder
+        self.tiles: list[pygame.Surface] = []
+        self.load_tiles()
+
+    def tiles_per_row(self) -> int:
+        """Return the number of tiles per row in the full tileset image."""
+        return self.TILESET_WIDTH // self.TILE_SIZE
+
+    def load_tiles(self) -> None:
+        """Load all tile images from the dungeon folder."""
+        if not os.path.isdir(self.tileset_folder):
+            return
+
+        png_files = [f for f in os.listdir(self.tileset_folder) if f.endswith('.png')]
+        png_files.sort()
+
+        for filename in png_files:
+            path = os.path.join(self.tileset_folder, filename)
+            sprite = sprite_cache.get_sprite(path)
+            if sprite is not None:
+                self.tiles.append(sprite)
+
+    def get_tile(self, index: int) -> pygame.Surface | None:
+        """Return the tile surface at the specified index."""
+        if 0 <= index < len(self.tiles):
+            return self.tiles[index]
+        return None
+
+    def tile_count(self) -> int:
+        """Return the number of loaded tiles."""
+        return len(self.tiles)

--- a/game_core/editor/tileset_tab/tileset_tab_manager.py
+++ b/game_core/editor/tileset_tab/tileset_tab_manager.py
@@ -6,6 +6,7 @@ import pygame
 
 from .show_overworld_tileset import draw_tileset as draw_overworld_tileset
 from .show_overworld_anim_tileset import draw_tileset as draw_overworld_anim_tileset
+from .show_dungeon_tileset import draw_tileset as draw_dungeon_tileset
 
 from ..color_palette import LIGHT_GRAY, DARK_GRAY, SIDEBAR_BORDER, WHITE
 from ..config import FONT_PATH
@@ -24,7 +25,11 @@ class TilesetTabManager:
 
         self.tilesets = [str(i) for i in range(1, 7)]
         self.active = 0
-        self._drawers = [draw_overworld_tileset, draw_overworld_anim_tileset]
+        self._drawers = [
+            draw_overworld_tileset,
+            draw_overworld_anim_tileset,
+            draw_dungeon_tileset,
+        ]
 
     def resize(self, sidebar_rect: pygame.Rect) -> None:
         """Update position and size when the sidebar changes."""


### PR DESCRIPTION
## Summary
- cap tileset scale factor to `2`
- add DungeonTileset loader
- render dungeon tileset on tileset tab 3

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842765682b4832db46b023a74460151