### PR TITLE
Add dungeon animated tileset

### DIFF
--- a/game_core/editor/tileset_tab/show_dungeon_anim_tileset.py
+++ b/game_core/editor/tileset_tab/show_dungeon_anim_tileset.py
@@ -1,0 +1,61 @@
+"""Utilities for displaying the animated dungeon tileset."""
+
+from __future__ import annotations
+
+from typing import Optional
+import pygame
+
+from .tileset_components import DungeonAnimTileset
+
+# Lazy loaded tileset instance
+_dungeon_anim_tileset: Optional[DungeonAnimTileset] = None
+
+
+def _get_dungeon_anim_tileset() -> DungeonAnimTileset:
+    """Return the singleton animated dungeon tileset, loading it if needed."""
+    global _dungeon_anim_tileset
+    if _dungeon_anim_tileset is None:
+        _dungeon_anim_tileset = DungeonAnimTileset()
+    return _dungeon_anim_tileset
+
+
+def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
+    """Draw the animated dungeon tileset in the sidebar."""
+
+    # Import here to avoid circular dependency during module initialization
+    from .tileset_tab_manager import TilesetTabManager
+
+    tileset = _get_dungeon_anim_tileset()
+
+    spacing = 2
+    tile_size = tileset.TILE_SIZE
+
+    tiles_per_row = tileset.tiles_per_row()
+    rows = (tileset.tile_count() + tiles_per_row - 1) // tiles_per_row
+
+    offset_y = TilesetTabManager.PADDING * 3 + TilesetTabManager.TAB_HEIGHT * 2
+
+    available_width = sidebar_rect.width
+    available_height = sidebar_rect.height - offset_y
+
+    scale_w = (available_width - spacing * tiles_per_row) / (tile_size * tiles_per_row)
+    scale_h = (available_height - spacing * (rows - 1)) / (tile_size * rows)
+
+    scale = min(scale_w, scale_h, 2)
+    if scale <= 0:
+        scale = 1
+
+    scaled_size = int(tile_size * scale)
+
+    grid_width = tiles_per_row * scaled_size + spacing * (tiles_per_row - 1)
+    start_x = sidebar_rect.left + max((available_width - grid_width) // 2, 0)
+    start_y = sidebar_rect.top + offset_y
+
+    for i in range(tileset.tile_count()):
+        tile = tileset.get_tile(i)
+        if tile is None:
+            continue
+        dest_x = start_x + (i % tiles_per_row) * (scaled_size + spacing)
+        dest_y = start_y + (i // tiles_per_row) * (scaled_size + spacing)
+        scaled = pygame.transform.scale(tile, (scaled_size, scaled_size))
+        surface.blit(scaled, (dest_x, dest_y))

--- a/game_core/editor/tileset_tab/tileset_components/__init__.py
+++ b/game_core/editor/tileset_tab/tileset_components/__init__.py
@@ -3,5 +3,11 @@
 from .overworld_tileset import OverworldTileset
 from .overworld_anim_tileset import OverworldAnimTileset
 from .dungeon_tileset import DungeonTileset
+from .dungeon_anim_tileset import DungeonAnimTileset
 
-__all__ = ["OverworldTileset", "OverworldAnimTileset", "DungeonTileset"]
+__all__ = [
+    "OverworldTileset",
+    "OverworldAnimTileset",
+    "DungeonTileset",
+    "DungeonAnimTileset",
+]

--- a/game_core/editor/tileset_tab/tileset_components/dungeon_anim_tileset.py
+++ b/game_core/editor/tileset_tab/tileset_components/dungeon_anim_tileset.py
@@ -1,0 +1,60 @@
+"""Loader for the animated dungeon tileset palette."""
+
+from __future__ import annotations
+
+import os
+import pygame
+
+from game_core.gameplay.other_components.image_cache import sprite_cache
+
+
+class DungeonAnimTileset:
+    """Load and store preview frames of animated dungeon tiles."""
+
+    TILE_SIZE = 16
+    # Animated tiles are arranged in a single row for preview
+    TILESET_WIDTH = TILE_SIZE * 5
+    TILESET_HEIGHT = TILE_SIZE
+
+    def __init__(self, tileset_folder: str = "Tilesets/Dungeon_ani_tiles") -> None:
+        self.tileset_folder = tileset_folder
+        self.tiles: list[pygame.Surface] = []
+        self.load_tiles()
+
+    def tiles_per_row(self) -> int:
+        """Return the number of tiles per row in the preview tileset."""
+        return self.TILESET_WIDTH // self.TILE_SIZE
+
+    def load_tiles(self) -> None:
+        """Load the first frame from each animated tile folder."""
+        if not os.path.isdir(self.tileset_folder):
+            return
+
+        tile_folders = [f for f in os.listdir(self.tileset_folder)
+                        if os.path.isdir(os.path.join(self.tileset_folder, f))]
+        tile_folders.sort()
+
+        for folder in tile_folders:
+            folder_path = os.path.join(self.tileset_folder, folder)
+            first_frame = os.path.join(folder_path, "tile000.png")
+
+            if not os.path.isfile(first_frame):
+                frame_files = [f for f in os.listdir(folder_path) if f.endswith(".png")]
+                frame_files.sort()
+                if not frame_files:
+                    continue
+                first_frame = os.path.join(folder_path, frame_files[0])
+
+            sprite = sprite_cache.get_sprite(first_frame)
+            if sprite is not None:
+                self.tiles.append(sprite)
+
+    def get_tile(self, index: int) -> pygame.Surface | None:
+        """Return the tile surface at the specified index."""
+        if 0 <= index < len(self.tiles):
+            return self.tiles[index]
+        return None
+
+    def tile_count(self) -> int:
+        """Return the number of loaded tiles."""
+        return len(self.tiles)

--- a/game_core/editor/tileset_tab/tileset_tab_manager.py
+++ b/game_core/editor/tileset_tab/tileset_tab_manager.py
@@ -7,6 +7,7 @@ import pygame
 from .show_overworld_tileset import draw_tileset as draw_overworld_tileset
 from .show_overworld_anim_tileset import draw_tileset as draw_overworld_anim_tileset
 from .show_dungeon_tileset import draw_tileset as draw_dungeon_tileset
+from .show_dungeon_anim_tileset import draw_tileset as draw_dungeon_anim_tileset
 
 from ..color_palette import LIGHT_GRAY, DARK_GRAY, SIDEBAR_BORDER, WHITE
 from ..config import FONT_PATH
@@ -29,6 +30,7 @@ class TilesetTabManager:
             draw_overworld_tileset,
             draw_overworld_anim_tileset,
             draw_dungeon_tileset,
+            draw_dungeon_anim_tileset,
         ]
 
     def resize(self, sidebar_rect: pygame.Rect) -> None:

--- a/game_core/gameplay/gameplay_components/animation_system/animated_tile_manager.py
+++ b/game_core/gameplay/gameplay_components/animation_system/animated_tile_manager.py
@@ -32,34 +32,38 @@ class AnimatedTileManager:
 
     def load_animated_tiles(self):
         """Load all animated tiles from the animated tiles folder"""
-        animated_tiles_folder = "Tilesets/Overworld_ani_tiles"
+        animated_tiles_folders = [
+            "Tilesets/Overworld_ani_tiles",
+            "Tilesets/Dungeon_ani_tiles",
+        ]
 
-        # Check if directory exists
-        if not os.path.exists(animated_tiles_folder):
-            pass  # Animated tiles folder not found
-            return
-
-        # Get all subdirectories (each subdirectory is an animated tile)
         try:
-            tile_folders = [f for f in os.listdir(animated_tiles_folder)
-                           if os.path.isdir(os.path.join(animated_tiles_folder, f))]
-
-            for folder in tile_folders:
-                folder_path = os.path.join(animated_tiles_folder, folder)
-
-                # Create an animated tile for this folder
-                animated_tile = AnimatedTile(folder_path)
-
-                # Skip if no frames were loaded
-                if not animated_tile.frames:
+            for animated_tiles_folder in animated_tiles_folders:
+                if not os.path.exists(animated_tiles_folder):
                     continue
 
-                # Store the animated tile
-                self.animated_tiles[folder] = animated_tile
+                tile_folders = [
+                    f
+                    for f in os.listdir(animated_tiles_folder)
+                    if os.path.isdir(os.path.join(animated_tiles_folder, f))
+                ]
 
-                # Assign a unique ID to this animated tile
-                self.animated_tile_ids[self.next_tile_id] = folder
-                self.next_tile_id += 1
+                for folder in tile_folders:
+                    folder_path = os.path.join(animated_tiles_folder, folder)
+
+                    # Create an animated tile for this folder
+                    animated_tile = AnimatedTile(folder_path)
+
+                    # Skip if no frames were loaded
+                    if not animated_tile.frames:
+                        continue
+
+                    # Store the animated tile
+                    self.animated_tiles[folder] = animated_tile
+
+                    # Assign a unique ID to this animated tile
+                    self.animated_tile_ids[self.next_tile_id] = folder
+                    self.next_tile_id += 1
 
             # Load key item animation
             key_item_folder = "character/Props_Items_(animated)/key_item_anim"


### PR DESCRIPTION
## Summary
- add dungeon animation component and viewer
- register dungeon animations alongside existing tiles
- update AnimatedTileManager to load dungeon animated tiles

## Testing
- `python -m compileall -q game_core/editor/tileset_tab/tileset_components/dungeon_anim_tileset.py game_core/editor/tileset_tab/show_dungeon_anim_tileset.py game_core/editor/tileset_tab/tileset_tab_manager.py game_core/editor/tileset_tab/tileset_components/__init__.py`
- `python -m compileall -q game_core/gameplay/gameplay_components/animation_system/animated_tile_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6842788d1df4832db4790ae8671b4a07