### PR TITLE
Fix animated dungeon tileset scaling

### DIFF
--- a/game_core/editor/tileset_tab/show_dungeon_anim_tileset.py
+++ b/game_core/editor/tileset_tab/show_dungeon_anim_tileset.py
@@ -27,27 +27,35 @@ def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
 
     tileset = _get_dungeon_anim_tileset()
 
-    spacing = 2
-    tile_size = tileset.TILE_SIZE
+    base_spacing = 2
+    tile_width = tileset.TILE_SIZE
 
     tiles_per_row = tileset.tiles_per_row()
     rows = (tileset.tile_count() + tiles_per_row - 1) // tiles_per_row
+
+    # Determine the tallest tile so scaling fits every frame
+    max_height = tile_width
+    for tile in tileset.tiles:
+        if tile is not None and tile.get_height() > max_height:
+            max_height = tile.get_height()
 
     offset_y = TilesetTabManager.PADDING * 3 + TilesetTabManager.TAB_HEIGHT * 2
 
     available_width = sidebar_rect.width
     available_height = sidebar_rect.height - offset_y
 
-    scale_w = (available_width - spacing * tiles_per_row) / (tile_size * tiles_per_row)
-    scale_h = (available_height - spacing * (rows - 1)) / (tile_size * rows)
+    scale_w = (available_width - base_spacing * tiles_per_row) / (tile_width * tiles_per_row)
+    scale_h = (available_height - base_spacing * (rows - 1)) / (max_height * rows)
 
     scale = min(scale_w, scale_h, 2)
     if scale <= 0:
         scale = 1
 
-    scaled_size = int(tile_size * scale)
+    spacing = int(base_spacing * scale)
+    scaled_width = int(tile_width * scale)
+    scaled_max_height = int(max_height * scale)
 
-    grid_width = tiles_per_row * scaled_size + spacing * (tiles_per_row - 1)
+    grid_width = tiles_per_row * scaled_width + spacing * (tiles_per_row - 1)
     start_x = sidebar_rect.left + max((available_width - grid_width) // 2, 0)
     start_y = sidebar_rect.top + offset_y
 
@@ -55,7 +63,11 @@ def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
         tile = tileset.get_tile(i)
         if tile is None:
             continue
-        dest_x = start_x + (i % tiles_per_row) * (scaled_size + spacing)
-        dest_y = start_y + (i // tiles_per_row) * (scaled_size + spacing)
-        scaled = pygame.transform.scale(tile, (scaled_size, scaled_size))
+        row = i // tiles_per_row
+        col = i % tiles_per_row
+        dest_x = start_x + col * (scaled_width + spacing)
+        dest_y = start_y + row * (scaled_max_height + spacing)
+        scaled_height = int(tile.get_height() * scale)
+        dest_y += scaled_max_height - scaled_height
+        scaled = pygame.transform.scale(tile, (scaled_width, scaled_height))
         surface.blit(scaled, (dest_x, dest_y))


### PR DESCRIPTION
## Summary
- scale animated dungeon tiles while preserving their original aspect ratio

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68427afa8ac4832d92c89f11ac2c0112