### PR TITLE
Add spawnpoint tilesets

### DIFF
--- a/game_core/editor/tileset_tab/show_enemy_spawnpoint.py
+++ b/game_core/editor/tileset_tab/show_enemy_spawnpoint.py
@@ -1,0 +1,91 @@
+"""Utilities for displaying enemy spawn point tiles."""
+
+from __future__ import annotations
+
+from typing import Optional
+import pygame
+
+from .tileset_components import EnemySpawnpointTileset
+
+_enemy_tileset: Optional[EnemySpawnpointTileset] = None
+
+
+def _get_enemy_tileset() -> EnemySpawnpointTileset:
+    """Return the singleton enemy spawn point tileset, loading it if needed."""
+    global _enemy_tileset
+    if _enemy_tileset is None:
+        _enemy_tileset = EnemySpawnpointTileset()
+    return _enemy_tileset
+
+
+def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
+    """Draw the enemy spawn point tiles in the sidebar."""
+    from .tileset_tab_manager import TilesetTabManager
+
+    tileset = _get_enemy_tileset()
+
+    base_spacing = 2
+
+    tiles_per_row = tileset.tiles_per_row()
+    rows = (tileset.tile_count() + tiles_per_row - 1) // tiles_per_row
+
+    tile_sizes: list[tuple[int, int]] = []
+    max_height = 0
+    for tile in tileset.tiles:
+        if tile is None:
+            continue
+        tile_sizes.append((tile.get_width(), tile.get_height()))
+        if tile.get_height() > max_height:
+            max_height = tile.get_height()
+
+    if max_height == 0:
+        return
+
+    offset_y = TilesetTabManager.PADDING * 3 + TilesetTabManager.TAB_HEIGHT * 2
+
+    available_width = sidebar_rect.width
+    available_height = sidebar_rect.height - offset_y
+
+    row_widths: list[int] = []
+    for r in range(rows):
+        start = r * tiles_per_row
+        end = start + tiles_per_row
+        row_tiles = tile_sizes[start:end]
+        width_sum = sum(w for w, _ in row_tiles)
+        row_widths.append(width_sum)
+    max_row_width = max(row_widths)
+
+    scale_w = (available_width - base_spacing * tiles_per_row) / max_row_width
+    scale_h = (available_height - base_spacing * (rows - 1)) / (max_height * rows)
+
+    scale = min(scale_w, scale_h, 2)
+    if scale <= 0:
+        scale = 1
+
+    spacing = int(base_spacing * scale)
+    scaled_max_height = int(max_height * scale)
+
+    scaled_row_widths = [
+        int(w * scale) + spacing * (min(tiles_per_row, tileset.tile_count() - r * tiles_per_row) - 1)
+        for r, w in enumerate(row_widths)
+    ]
+    grid_width = max(scaled_row_widths)
+
+    start_x = sidebar_rect.left + max((available_width - grid_width) // 2, 0)
+    start_y = sidebar_rect.top + offset_y
+
+    for row in range(rows):
+        row_start = row * tiles_per_row
+        row_end = row_start + tiles_per_row
+        row_tiles = tileset.tiles[row_start:row_end]
+        dest_x = start_x + max((grid_width - scaled_row_widths[row]) // 2, 0)
+        dest_y_base = start_y + row * (scaled_max_height + spacing)
+        for tile in row_tiles:
+            if tile is None:
+                continue
+            scaled_w = int(tile.get_width() * scale)
+            scaled_h = int(tile.get_height() * scale)
+            dest_y = dest_y_base + scaled_max_height - scaled_h
+            scaled = pygame.transform.scale(tile, (scaled_w, scaled_h))
+            surface.blit(scaled, (dest_x, dest_y))
+            dest_x += scaled_w + spacing

--- a/game_core/editor/tileset_tab/show_player_spawnpoint.py
+++ b/game_core/editor/tileset_tab/show_player_spawnpoint.py
@@ -1,0 +1,58 @@
+"""Utilities for displaying the player spawn point tile."""
+
+from __future__ import annotations
+
+from typing import Optional
+import pygame
+
+from .tileset_components import PlayerSpawnpointTileset
+
+_player_tileset: Optional[PlayerSpawnpointTileset] = None
+
+
+def _get_player_tileset() -> PlayerSpawnpointTileset:
+    """Return the singleton player spawn point tileset, loading it if needed."""
+    global _player_tileset
+    if _player_tileset is None:
+        _player_tileset = PlayerSpawnpointTileset()
+    return _player_tileset
+
+
+def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
+    """Draw the player spawn point tile in the sidebar."""
+    from .tileset_tab_manager import TilesetTabManager
+
+    tileset = _get_player_tileset()
+
+    spacing = 2
+    tile_size = tileset.TILE_SIZE
+
+    tiles_per_row = tileset.tiles_per_row()
+    rows = (tileset.tile_count() + tiles_per_row - 1) // tiles_per_row
+
+    offset_y = TilesetTabManager.PADDING * 3 + TilesetTabManager.TAB_HEIGHT * 2
+
+    available_width = sidebar_rect.width
+    available_height = sidebar_rect.height - offset_y
+
+    scale_w = (available_width - spacing * tiles_per_row) / (tile_size * tiles_per_row)
+    scale_h = (available_height - spacing * (rows - 1)) / (tile_size * rows)
+
+    scale = min(scale_w, scale_h, 2)
+    if scale <= 0:
+        scale = 1
+
+    scaled_size = int(tile_size * scale)
+
+    grid_width = tiles_per_row * scaled_size + spacing * (tiles_per_row - 1)
+    start_x = sidebar_rect.left + max((available_width - grid_width) // 2, 0)
+    start_y = sidebar_rect.top + offset_y
+
+    for i in range(tileset.tile_count()):
+        tile = tileset.get_tile(i)
+        if tile is None:
+            continue
+        dest_x = start_x + (i % tiles_per_row) * (scaled_size + spacing)
+        dest_y = start_y + (i // tiles_per_row) * (scaled_size + spacing)
+        scaled = pygame.transform.scale(tile, (scaled_size, scaled_size))
+        surface.blit(scaled, (dest_x, dest_y))

--- a/game_core/editor/tileset_tab/tileset_components/__init__.py
+++ b/game_core/editor/tileset_tab/tileset_components/__init__.py
@@ -4,10 +4,14 @@ from .overworld_tileset import OverworldTileset
 from .overworld_anim_tileset import OverworldAnimTileset
 from .dungeon_tileset import DungeonTileset
 from .dungeon_anim_tileset import DungeonAnimTileset
+from .player_spawnpoint import PlayerSpawnpointTileset
+from .enemy_spawnpoint import EnemySpawnpointTileset
 
 __all__ = [
     "OverworldTileset",
     "OverworldAnimTileset",
     "DungeonTileset",
     "DungeonAnimTileset",
+    "PlayerSpawnpointTileset",
+    "EnemySpawnpointTileset",
 ]

--- a/game_core/editor/tileset_tab/tileset_components/enemy_spawnpoint.py
+++ b/game_core/editor/tileset_tab/tileset_components/enemy_spawnpoint.py
@@ -1,0 +1,63 @@
+"""Tileset with preview tiles for enemy spawn points."""
+
+from __future__ import annotations
+
+import os
+import pygame
+
+from game_core.gameplay.other_components.image_cache import sprite_cache
+
+
+class EnemySpawnpointTileset:
+    """Load preview tiles for enemy spawn points from various enemy folders."""
+
+    TILE_SIZE = 16
+    TILESET_WIDTH = TILE_SIZE * 6
+    TILESET_HEIGHT = TILE_SIZE
+
+    def __init__(self, enemies_root: str = "Enemies_Sprites") -> None:
+        self.enemies_root = enemies_root
+        self.enemy_folders = [
+            "Bomberplant_Sprites",
+            "Phantom_Sprites",
+            "Pinkbat_Sprites",
+            "Pinkslime_Sprites",
+            "Spider_Sprites",
+            "Spinner_Sprites",
+        ]
+        self.tiles: list[pygame.Surface] = []
+        self.load_tiles()
+
+    def tiles_per_row(self) -> int:
+        """Return the number of tiles per row in the preview tileset."""
+        return self.TILESET_WIDTH // self.TILE_SIZE
+
+    def _find_first_png(self, folder: str) -> str | None:
+        for root, _dirs, files in os.walk(folder):
+            png_files = [f for f in files if f.endswith(".png")]
+            png_files.sort()
+            if png_files:
+                return os.path.join(root, png_files[0])
+        return None
+
+    def load_tiles(self) -> None:
+        """Load the first frame from each enemy folder."""
+        for folder in self.enemy_folders:
+            base_path = os.path.join(self.enemies_root, folder)
+            if not os.path.isdir(base_path):
+                continue
+            first_png = self._find_first_png(base_path)
+            if first_png and os.path.isfile(first_png):
+                sprite = sprite_cache.get_sprite(first_png)
+                if sprite is not None:
+                    self.tiles.append(sprite)
+
+    def get_tile(self, index: int) -> pygame.Surface | None:
+        """Return the tile surface at the specified index."""
+        if 0 <= index < len(self.tiles):
+            return self.tiles[index]
+        return None
+
+    def tile_count(self) -> int:
+        """Return the number of loaded tiles."""
+        return len(self.tiles)

--- a/game_core/editor/tileset_tab/tileset_components/player_spawnpoint.py
+++ b/game_core/editor/tileset_tab/tileset_components/player_spawnpoint.py
@@ -1,0 +1,44 @@
+"""Tileset with a single tile representing the player spawn point."""
+
+from __future__ import annotations
+
+import os
+import pygame
+
+from game_core.gameplay.other_components.image_cache import sprite_cache
+
+
+class PlayerSpawnpointTileset:
+    """Load the player spawn point preview tile."""
+
+    TILE_SIZE = 16
+    TILESET_WIDTH = TILE_SIZE
+    TILESET_HEIGHT = TILE_SIZE
+
+    def __init__(self, tile_path: str = "character/char_idle_up/tile000.png") -> None:
+        self.tile_path = tile_path
+        self.tiles: list[pygame.Surface] = []
+        self.load_tiles()
+
+    def tiles_per_row(self) -> int:
+        """Return the number of tiles per row in this tileset."""
+        return 1
+
+    def load_tiles(self) -> None:
+        """Load the player spawn tile if it exists."""
+        if not os.path.isfile(self.tile_path):
+            return
+
+        sprite = sprite_cache.get_sprite(self.tile_path)
+        if sprite is not None:
+            self.tiles.append(sprite)
+
+    def get_tile(self, index: int) -> pygame.Surface | None:
+        """Return the tile surface at the specified index."""
+        if 0 <= index < len(self.tiles):
+            return self.tiles[index]
+        return None
+
+    def tile_count(self) -> int:
+        """Return the number of loaded tiles."""
+        return len(self.tiles)

--- a/game_core/editor/tileset_tab/tileset_tab_manager.py
+++ b/game_core/editor/tileset_tab/tileset_tab_manager.py
@@ -8,6 +8,8 @@ from .show_overworld_tileset import draw_tileset as draw_overworld_tileset
 from .show_overworld_anim_tileset import draw_tileset as draw_overworld_anim_tileset
 from .show_dungeon_tileset import draw_tileset as draw_dungeon_tileset
 from .show_dungeon_anim_tileset import draw_tileset as draw_dungeon_anim_tileset
+from .show_player_spawnpoint import draw_tileset as draw_player_spawnpoint
+from .show_enemy_spawnpoint import draw_tileset as draw_enemy_spawnpoint
 
 from ..color_palette import LIGHT_GRAY, DARK_GRAY, SIDEBAR_BORDER, WHITE
 from ..config import FONT_PATH
@@ -31,6 +33,8 @@ class TilesetTabManager:
             draw_overworld_anim_tileset,
             draw_dungeon_tileset,
             draw_dungeon_anim_tileset,
+            draw_player_spawnpoint,
+            draw_enemy_spawnpoint,
         ]
 
     def resize(self, sidebar_rect: pygame.Rect) -> None:


### PR DESCRIPTION
## Summary
- add a tileset loader for player spawn points
- add a tileset loader for enemy spawn points
- display the new tilesets in tabs 5 and 6

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684282645be8832dac58fb6704bc7431