### PR TITLE
Add tile selection manager

### DIFF
--- a/game_core/editor/__init__.py
+++ b/game_core/editor/__init__.py
@@ -1,9 +1,11 @@
 """Editor package containing editor-specific modules."""
 
-__all__ = ["Sidebar", "Canvas", "TabManager", "TilesetTabManager", "sprite_cache"]
+__all__ = ["Sidebar", "Canvas", "TabManager", "TilesetTabManager",
+           "TileSelectionManager", "sprite_cache"]
 
 from .sidebar import Sidebar
 from .canvas import Canvas
 from .sidebar.sidebar_tab_manager import TabManager
 from .tileset_tab.tileset_tab_manager import TilesetTabManager
+from .tileset_tab.tile_selection_manager import TileSelectionManager
 from .image_cache import sprite_cache

--- a/game_core/editor/sidebar/sidebar_tab_manager.py
+++ b/game_core/editor/sidebar/sidebar_tab_manager.py
@@ -7,6 +7,7 @@ import pygame
 from ..color_palette import LIGHT_GRAY, DARK_GRAY, SIDEBAR_BORDER, WHITE
 from ..config import FONT_PATH
 from ..tileset_tab.tileset_tab_manager import TilesetTabManager
+from ..tileset_tab.tile_selection_manager import TileSelectionManager
 
 
 class TabManager:
@@ -22,13 +23,20 @@ class TabManager:
         self.sidebar_rect = sidebar_rect
         self.font = pygame.font.Font(FONT_PATH, 16)
 
+        # Tile selection manager used by the tileset manager
+        self.selection_manager = TileSelectionManager()
         # Manager for the numeric tileset tabs
-        self.tileset_manager = TilesetTabManager(sidebar_rect)
+        self.tileset_manager = TilesetTabManager(sidebar_rect, self.selection_manager)
 
     @property
     def active_tileset(self) -> int:
         """Index of the currently selected tileset."""
         return self.tileset_manager.active
+
+    @property
+    def selected_tile(self) -> int | None:
+        """Currently selected tile index for the active tileset."""
+        return self.selection_manager.get_selected(self.tileset_manager.active)
 
     def resize(self, sidebar_rect: pygame.Rect) -> None:
         """Update the sidebar reference when resized."""

--- a/game_core/editor/tileset_tab/show_dungeon_anim_tileset.py
+++ b/game_core/editor/tileset_tab/show_dungeon_anim_tileset.py
@@ -19,8 +19,8 @@ def _get_dungeon_anim_tileset() -> DungeonAnimTileset:
     return _dungeon_anim_tileset
 
 
-def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
-    """Draw the animated dungeon tileset in the sidebar."""
+def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> list[pygame.Rect]:
+    """Draw the animated dungeon tileset in the sidebar and return tile rectangles."""
 
     # Import here to avoid circular dependency during module initialization
     from .tileset_tab_manager import TilesetTabManager
@@ -43,7 +43,7 @@ def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
             max_height = tile.get_height()
 
     if max_height == 0:
-        return
+        return []
 
     offset_y = TilesetTabManager.PADDING * 3 + TilesetTabManager.TAB_HEIGHT * 2
 
@@ -77,6 +77,7 @@ def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
     start_x = sidebar_rect.left + max((available_width - grid_width) // 2, 0)
     start_y = sidebar_rect.top + offset_y
 
+    rects: list[pygame.Rect] = []
     for row in range(rows):
         row_start = row * tiles_per_row
         row_end = row_start + tiles_per_row
@@ -91,4 +92,7 @@ def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
             dest_y = dest_y_base + scaled_max_height - scaled_h
             scaled = pygame.transform.scale(tile, (scaled_w, scaled_h))
             surface.blit(scaled, (dest_x, dest_y))
+            rects.append(pygame.Rect(dest_x, dest_y, scaled_w, scaled_h))
             dest_x += scaled_w + spacing
+
+    return rects

--- a/game_core/editor/tileset_tab/show_dungeon_tileset.py
+++ b/game_core/editor/tileset_tab/show_dungeon_tileset.py
@@ -19,8 +19,8 @@ def _get_dungeon_tileset() -> DungeonTileset:
     return _dungeon_tileset
 
 
-def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
-    """Draw the dungeon tileset inside the sidebar."""
+def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> list[pygame.Rect]:
+    """Draw the dungeon tileset inside the sidebar and return tile rectangles."""
 
     # Import here to avoid circular dependency during module initialization
     from .tileset_tab_manager import TilesetTabManager
@@ -53,6 +53,7 @@ def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
     start_x = sidebar_rect.left + max((available_width - grid_width) // 2, 0)
     start_y = sidebar_rect.top + offset_y
 
+    rects: list[pygame.Rect] = []
     for i in range(tileset.tile_count()):
         tile = tileset.get_tile(i)
         if tile is None:
@@ -61,3 +62,6 @@ def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
         dest_y = start_y + (i // tiles_per_row) * (scaled_size + spacing)
         scaled = pygame.transform.scale(tile, (scaled_size, scaled_size))
         surface.blit(scaled, (dest_x, dest_y))
+        rects.append(pygame.Rect(dest_x, dest_y, scaled_size, scaled_size))
+
+    return rects

--- a/game_core/editor/tileset_tab/show_enemy_spawnpoint.py
+++ b/game_core/editor/tileset_tab/show_enemy_spawnpoint.py
@@ -18,8 +18,8 @@ def _get_enemy_tileset() -> EnemySpawnpointTileset:
     return _enemy_tileset
 
 
-def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
-    """Draw the enemy spawn point tiles in the sidebar."""
+def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> list[pygame.Rect]:
+    """Draw the enemy spawn point tiles in the sidebar and return tile rectangles."""
     from .tileset_tab_manager import TilesetTabManager
 
     tileset = _get_enemy_tileset()
@@ -39,7 +39,7 @@ def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
             max_height = tile.get_height()
 
     if max_height == 0:
-        return
+        return []
 
     offset_y = TilesetTabManager.PADDING * 3 + TilesetTabManager.TAB_HEIGHT * 2
 
@@ -74,6 +74,7 @@ def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
     start_x = sidebar_rect.left + max((available_width - grid_width) // 2, 0)
     start_y = sidebar_rect.top + offset_y
 
+    rects: list[pygame.Rect] = []
     for row in range(rows):
         row_start = row * tiles_per_row
         row_end = row_start + tiles_per_row
@@ -88,4 +89,7 @@ def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
             dest_y = dest_y_base + scaled_max_height - scaled_h
             scaled = pygame.transform.scale(tile, (scaled_w, scaled_h))
             surface.blit(scaled, (dest_x, dest_y))
+            rects.append(pygame.Rect(dest_x, dest_y, scaled_w, scaled_h))
             dest_x += scaled_w + spacing
+
+    return rects

--- a/game_core/editor/tileset_tab/show_overworld_anim_tileset.py
+++ b/game_core/editor/tileset_tab/show_overworld_anim_tileset.py
@@ -19,8 +19,8 @@ def _get_overworld_anim_tileset() -> OverworldAnimTileset:
     return _overworld_anim_tileset
 
 
-def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
-    """Draw the animated overworld tileset in the sidebar."""
+def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> list[pygame.Rect]:
+    """Draw the animated overworld tileset in the sidebar and return tile rectangles."""
 
     # Import here to avoid circular dependency during module initialization
     from .tileset_tab_manager import TilesetTabManager
@@ -53,6 +53,7 @@ def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
     start_x = sidebar_rect.left + max((available_width - grid_width) // 2, 0)
     start_y = sidebar_rect.top + offset_y
 
+    rects: list[pygame.Rect] = []
     for i in range(tileset.tile_count()):
         tile = tileset.get_tile(i)
         if tile is None:
@@ -61,3 +62,6 @@ def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
         dest_y = start_y + (i // tiles_per_row) * (scaled_size + spacing)
         scaled = pygame.transform.scale(tile, (scaled_size, scaled_size))
         surface.blit(scaled, (dest_x, dest_y))
+        rects.append(pygame.Rect(dest_x, dest_y, scaled_size, scaled_size))
+
+    return rects

--- a/game_core/editor/tileset_tab/show_overworld_tileset.py
+++ b/game_core/editor/tileset_tab/show_overworld_tileset.py
@@ -19,8 +19,8 @@ def _get_overworld_tileset() -> OverworldTileset:
     return _overworld_tileset
 
 
-def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
-    """Draw the overworld tileset inside the sidebar."""
+def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> list[pygame.Rect]:
+    """Draw the overworld tileset inside the sidebar and return tile rectangles."""
 
     # Import here to avoid circular dependency during module initialization
     from .tileset_tab_manager import TilesetTabManager
@@ -53,6 +53,7 @@ def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
     start_x = sidebar_rect.left + max((available_width - grid_width) // 2, 0)
     start_y = sidebar_rect.top + offset_y
 
+    rects: list[pygame.Rect] = []
     for i in range(tileset.tile_count()):
         tile = tileset.get_tile(i)
         if tile is None:
@@ -61,3 +62,6 @@ def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
         dest_y = start_y + (i // tiles_per_row) * (scaled_size + spacing)
         scaled = pygame.transform.scale(tile, (scaled_size, scaled_size))
         surface.blit(scaled, (dest_x, dest_y))
+        rects.append(pygame.Rect(dest_x, dest_y, scaled_size, scaled_size))
+
+    return rects

--- a/game_core/editor/tileset_tab/show_player_spawnpoint.py
+++ b/game_core/editor/tileset_tab/show_player_spawnpoint.py
@@ -18,8 +18,8 @@ def _get_player_tileset() -> PlayerSpawnpointTileset:
     return _player_tileset
 
 
-def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
-    """Draw the player spawn point tile in the sidebar."""
+def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> list[pygame.Rect]:
+    """Draw the player spawn point tile in the sidebar and return tile rectangles."""
     from .tileset_tab_manager import TilesetTabManager
 
     tileset = _get_player_tileset()
@@ -48,6 +48,7 @@ def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
     start_x = sidebar_rect.left + max((available_width - grid_width) // 2, 0)
     start_y = sidebar_rect.top + offset_y
 
+    rects: list[pygame.Rect] = []
     for i in range(tileset.tile_count()):
         tile = tileset.get_tile(i)
         if tile is None:
@@ -56,3 +57,6 @@ def draw_tileset(surface: pygame.Surface, sidebar_rect: pygame.Rect) -> None:
         dest_y = start_y + (i // tiles_per_row) * (scaled_size + spacing)
         scaled = pygame.transform.scale(tile, (scaled_size, scaled_size))
         surface.blit(scaled, (dest_x, dest_y))
+        rects.append(pygame.Rect(dest_x, dest_y, scaled_size, scaled_size))
+
+    return rects

--- a/game_core/editor/tileset_tab/tile_selection_manager.py
+++ b/game_core/editor/tileset_tab/tile_selection_manager.py
@@ -1,0 +1,46 @@
+"""Manage tile selection across all tileset palettes."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+import pygame
+
+from ..color_palette import ORANGE
+
+
+class TileSelectionManager:
+    """Track and draw tile selections for each tileset."""
+
+    def __init__(self) -> None:
+        self.selections: Dict[int, int] = {}
+        self.tile_rects: Dict[int, List[pygame.Rect]] = {}
+
+    def set_tile_rects(self, tileset_index: int, rects: List[pygame.Rect]) -> None:
+        """Store rectangles for tiles in the given tileset."""
+        self.tile_rects[tileset_index] = rects
+
+    def handle_event(self, event: pygame.event.Event, tileset_index: int) -> None:
+        """Update selection for the active tileset based on mouse click."""
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            rects = self.tile_rects.get(tileset_index)
+            if not rects:
+                return
+            mx, my = event.pos
+            for index, rect in enumerate(rects):
+                if rect.collidepoint(mx, my):
+                    self.selections[tileset_index] = index
+                    break
+
+    def draw_selection(self, surface: pygame.Surface, tileset_index: int) -> None:
+        """Highlight the currently selected tile for the active tileset."""
+        rects = self.tile_rects.get(tileset_index)
+        if not rects:
+            return
+        index = self.selections.get(tileset_index)
+        if index is None or index >= len(rects):
+            return
+        pygame.draw.rect(surface, ORANGE, rects[index], 2)
+
+    def get_selected(self, tileset_index: int) -> int | None:
+        """Return the selected tile index for a tileset."""
+        return self.selections.get(tileset_index)


### PR DESCRIPTION
## Summary
- add a new `TileSelectionManager` for managing palette selections
- integrate selection manager into the sidebar and tileset tabs
- return tile rectangles from tileset drawing helpers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68428e0a860c832da0e06751ad6f5666