### PR TITLE
Implement tile placement controls

### DIFF
--- a/editor_app.py
+++ b/editor_app.py
@@ -15,6 +15,8 @@ from game_core.editor.config import (
 )
 from game_core.editor.sidebar import Sidebar, SIDEBAR_WIDTH
 from game_core.editor.canvas import Canvas
+
+# NOTE: Avoid embedding placement logic directly in this file.
 from game_core.editor.sidebar.sidebar_tab_manager import TabManager
 
 
@@ -65,6 +67,9 @@ class EditorApp:
             elif event.type == pygame.KEYDOWN and event.key == pygame.K_F11:
                 self.toggle_fullscreen()
             self.tab_manager.handle_event(event)
+            # Tile placement is handled by the canvas module; keep logic out of
+            # EditorApp to simplify maintenance.
+            self.canvas.handle_event(event, self.tab_manager)
 
     def update(self):
         pass

--- a/game_core/editor/canvas/__init__.py
+++ b/game_core/editor/canvas/__init__.py
@@ -2,5 +2,6 @@
 
 from .canvas import Canvas
 from .tile_placement import TilePlacementManager
+from .tileset_repository import TilesetRepository
 
-__all__ = ["Canvas", "TilePlacementManager"]
+__all__ = ["Canvas", "TilePlacementManager", "TilesetRepository"]

--- a/game_core/editor/canvas/canvas.py
+++ b/game_core/editor/canvas/canvas.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import pygame
 
 from ..color_palette import LIGHT_GRAY, DARK_GRAY, WHITE
+from .tile_placement import TilePlacementManager
+from .tileset_repository import TilesetRepository
+from ..sidebar.sidebar_tab_manager import TabManager
 
 
 class Canvas:
@@ -13,10 +16,28 @@ class Canvas:
     def __init__(self, width: int, height: int, grid_size: int = 16, x: int = 0, y: int = 0) -> None:
         self.grid_size = grid_size
         self.rect = pygame.Rect(x, y, width, height)
+        self.placement_manager = TilePlacementManager(grid_size)
+        self.tilesets = TilesetRepository()
 
     def resize(self, width: int, height: int, x: int = 0, y: int = 0) -> None:
         """Resize and reposition the canvas."""
         self.rect.update(x, y, width, height)
+
+    def handle_event(self, event: pygame.event.Event, tab_manager: TabManager) -> None:
+        """Handle mouse events for placing and removing tiles."""
+        if event.type == pygame.MOUSEBUTTONDOWN and self.rect.collidepoint(event.pos):
+            mx, my = event.pos
+            grid_x = (mx - self.rect.left) // self.grid_size
+            grid_y = (my - self.rect.top) // self.grid_size
+            if event.button == 1:
+                tile_index = tab_manager.selected_tile
+                tileset_index = tab_manager.active_tileset
+                if tile_index is not None:
+                    tile = self.tilesets.get_tile(tileset_index, tile_index)
+                    if tile is not None:
+                        self.placement_manager.add_tile(tile, grid_x, grid_y)
+            elif event.button == 3:
+                self.placement_manager.remove_tile_at(grid_x, grid_y)
 
     def draw(self, surface: pygame.Surface) -> None:
         """Draw the canvas background and grid."""
@@ -29,3 +50,6 @@ class Canvas:
         # Draw horizontal grid lines
         for gy in range(self.rect.top, self.rect.bottom, self.grid_size):
             pygame.draw.line(surface, LIGHT_GRAY, (self.rect.left, gy), (self.rect.right, gy))
+
+        # Draw any placed tiles on top of the grid
+        self.placement_manager.draw(surface)

--- a/game_core/editor/canvas/tileset_repository.py
+++ b/game_core/editor/canvas/tileset_repository.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pygame
+
+from ..tileset_tab.tileset_components import (
+    OverworldTileset,
+    OverworldAnimTileset,
+    DungeonTileset,
+    DungeonAnimTileset,
+    PlayerSpawnpointTileset,
+    EnemySpawnpointTileset,
+)
+
+
+class TilesetRepository:
+    """Load and provide tile surfaces for placement."""
+
+    def __init__(self) -> None:
+        self._tilesets = [
+            OverworldTileset(),
+            OverworldAnimTileset(),
+            DungeonTileset(),
+            DungeonAnimTileset(),
+            PlayerSpawnpointTileset(),
+            EnemySpawnpointTileset(),
+        ]
+
+    def get_tile(self, tileset_index: int, tile_index: int) -> pygame.Surface | None:
+        """Return a tile from the specified tileset."""
+        if 0 <= tileset_index < len(self._tilesets):
+            return self._tilesets[tileset_index].get_tile(tile_index)
+        return None


### PR DESCRIPTION
## Summary
- route placement logic through canvas to keep EditorApp slim
- introduce `TilesetRepository` to fetch tile images for placement
- handle left-click placement and right-click removal inside `Canvas`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68429e93a7b8832d9a08333c88d90ac1