### PR TITLE
Add canvas controls module

### DIFF
--- a/editor_app.py
+++ b/editor_app.py
@@ -14,7 +14,7 @@ from game_core.editor.config import (
     maintain_aspect_ratio,
 )
 from game_core.editor.sidebar import Sidebar, SIDEBAR_WIDTH
-from game_core.editor.canvas import Canvas
+from game_core.editor.canvas import Canvas, CanvasControls
 
 # NOTE: Avoid embedding placement logic directly in this file.
 from game_core.editor.sidebar.sidebar_tab_manager import TabManager
@@ -38,6 +38,7 @@ class EditorApp:
         # Editor UI components
         self.sidebar = Sidebar(self.height, self.width - SIDEBAR_WIDTH)
         self.canvas = Canvas(self.width - SIDEBAR_WIDTH, self.height)
+        self.controls = CanvasControls(self.canvas)
         self.tab_manager = TabManager(["tiles", "browse", "save"], self.sidebar.rect)
 
     def toggle_fullscreen(self) -> None:
@@ -67,9 +68,13 @@ class EditorApp:
             elif event.type == pygame.KEYDOWN and event.key == pygame.K_F11:
                 self.toggle_fullscreen()
             self.tab_manager.handle_event(event)
-            # Tile placement is handled by the canvas module; keep logic out of
-            # EditorApp to simplify maintenance.
-            self.canvas.handle_event(event, self.tab_manager)
+
+            # Canvas navigation/zoom/dragging
+            self.controls.handle_event(event)
+
+            # Skip placement while dragging a tile
+            if self.controls.dragging is None:
+                self.canvas.handle_event(event, self.tab_manager)
 
     def update(self):
         pass

--- a/game_core/editor/canvas/__init__.py
+++ b/game_core/editor/canvas/__init__.py
@@ -3,5 +3,11 @@
 from .canvas import Canvas
 from .tile_placement import TilePlacementManager
 from .tileset_repository import TilesetRepository
+from .canvas_controls import CanvasControls
 
-__all__ = ["Canvas", "TilePlacementManager", "TilesetRepository"]
+__all__ = [
+    "Canvas",
+    "TilePlacementManager",
+    "TilesetRepository",
+    "CanvasControls",
+]

--- a/game_core/editor/canvas/canvas_controls.py
+++ b/game_core/editor/canvas/canvas_controls.py
@@ -1,0 +1,106 @@
+"""Utilities for interacting with the editor canvas."""
+
+from __future__ import annotations
+
+import pygame
+
+from .canvas import Canvas
+from .tile_placement import PlacedTile
+
+
+class CanvasControls:
+    """Handle panning, zooming and dragging of canvas tiles."""
+
+    PAN_SPEED = 10  # pixels moved per key press
+
+    def __init__(self, canvas: Canvas) -> None:
+        self.canvas = canvas
+        self.dragging: PlacedTile | None = None
+        self.drag_offset = (0, 0)
+
+    # ------------------------------------------------------------------
+    # Dragging tiles
+    # ------------------------------------------------------------------
+    def _tile_at_pos(self, pos: tuple[int, int]) -> PlacedTile | None:
+        for tile in reversed(self.canvas.placement_manager.tiles):
+            if tile.rect.collidepoint(pos):
+                return tile
+        return None
+
+    def _start_drag(self, pos: tuple[int, int]) -> None:
+        tile = self._tile_at_pos(pos)
+        if tile:
+            self.dragging = tile
+            self.drag_offset = (pos[0] - tile.rect.x, pos[1] - tile.rect.y)
+
+    def _update_drag(self, pos: tuple[int, int]) -> None:
+        if self.dragging:
+            new_x = pos[0] - self.drag_offset[0]
+            new_y = pos[1] - self.drag_offset[1]
+            self.dragging.rect.topleft = (new_x, new_y)
+
+    def _end_drag(self) -> None:
+        if self.dragging:
+            x = self.dragging.rect.x - self.canvas.rect.left
+            y = self.dragging.rect.y - self.canvas.rect.top
+            grid = self.canvas.grid_size
+            snapped_x = (x // grid) * grid + self.canvas.rect.left
+            snapped_y = (y // grid) * grid + self.canvas.rect.top
+            self.dragging.rect.topleft = (snapped_x, snapped_y)
+        self.dragging = None
+
+    # ------------------------------------------------------------------
+    # Canvas navigation
+    # ------------------------------------------------------------------
+    def _pan(self, dx: int, dy: int) -> None:
+        self.canvas.rect.move_ip(dx, dy)
+        for tile in self.canvas.placement_manager.tiles:
+            tile.rect.move_ip(dx, dy)
+
+    # ------------------------------------------------------------------
+    # Zoom handling
+    # ------------------------------------------------------------------
+    def _zoom(self, factor: float) -> None:
+        old_size = self.canvas.grid_size
+        new_size = max(1, int(old_size * factor))
+        if new_size == old_size:
+            return
+        scale = new_size / old_size
+        self.canvas.grid_size = new_size
+        self.canvas.placement_manager.grid_size = new_size
+
+        for tile in self.canvas.placement_manager.tiles:
+            rel_x = tile.rect.x - self.canvas.rect.left
+            rel_y = tile.rect.y - self.canvas.rect.top
+            tile.rect.x = int(rel_x * scale + self.canvas.rect.left)
+            tile.rect.y = int(rel_y * scale + self.canvas.rect.top)
+            tile.rect.width = int(tile.rect.width * scale)
+            tile.rect.height = int(tile.rect.height * scale)
+            tile.image = pygame.transform.scale(tile.image, tile.rect.size)
+
+    def handle_event(self, event: pygame.event.Event) -> None:
+        """Process Pygame events for canvas controls."""
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            self._start_drag(event.pos)
+        elif event.type == pygame.MOUSEMOTION:
+            if self.dragging and event.buttons[0]:
+                self._update_drag(event.pos)
+        elif event.type == pygame.MOUSEBUTTONUP and event.button == 1:
+            self._end_drag()
+        elif event.type == pygame.KEYDOWN:
+            # WASD panning
+            if event.key == pygame.K_w:
+                self._pan(0, -self.PAN_SPEED)
+            elif event.key == pygame.K_s:
+                self._pan(0, self.PAN_SPEED)
+            elif event.key == pygame.K_a:
+                self._pan(-self.PAN_SPEED, 0)
+            elif event.key == pygame.K_d:
+                self._pan(self.PAN_SPEED, 0)
+
+            # Ctrl + / - zooming
+            if event.mod & pygame.KMOD_CTRL:
+                if event.key in (pygame.K_EQUALS, pygame.K_KP_PLUS):
+                    self._zoom(2.0)
+                elif event.key in (pygame.K_MINUS, pygame.K_KP_MINUS):
+                    self._zoom(0.5)


### PR DESCRIPTION
## Summary
- support dragging, panning, and zooming the editor canvas via `CanvasControls`
- export the new class from the canvas package
- wire up controls in `EditorApp`

## Testing
- `python -m py_compile game_core/editor/canvas/canvas_controls.py editor_app.py`
- `python -m py_compile game_core/editor/canvas/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6842a53c05f4832d9ce69975b8c3b459