### PR TITLE
Fix canvas controls in editor

### DIFF
--- a/editor_app.py
+++ b/editor_app.py
@@ -14,7 +14,7 @@ from game_core.editor.config import (
     maintain_aspect_ratio,
 )
 from game_core.editor.sidebar import Sidebar, SIDEBAR_WIDTH
-from game_core.editor.canvas import Canvas
+from game_core.editor.canvas import Canvas, CanvasControls
 
 # NOTE: Avoid embedding placement logic directly in this file.
 from game_core.editor.sidebar.sidebar_tab_manager import TabManager
@@ -38,6 +38,7 @@ class EditorApp:
         # Editor UI components
         self.sidebar = Sidebar(self.height, self.width - SIDEBAR_WIDTH)
         self.canvas = Canvas(self.width - SIDEBAR_WIDTH, self.height)
+        self.canvas_controls = CanvasControls(self.canvas)
         self.tab_manager = TabManager(["tiles", "browse", "save"], self.sidebar.rect)
 
     def toggle_fullscreen(self) -> None:
@@ -67,9 +68,11 @@ class EditorApp:
             elif event.type == pygame.KEYDOWN and event.key == pygame.K_F11:
                 self.toggle_fullscreen()
             self.tab_manager.handle_event(event)
-            # Tile placement is handled by the canvas module; keep logic out of
-            # EditorApp to simplify maintenance.
-            self.canvas.handle_event(event, self.tab_manager)
+            handled = self.canvas_controls.handle_event(event)
+            if not handled:
+                # Tile placement is handled by the canvas module; keep logic out of
+                # EditorApp to simplify maintenance.
+                self.canvas.handle_event(event, self.tab_manager)
 
     def update(self):
         pass

--- a/game_core/editor/canvas/canvas_controls.py
+++ b/game_core/editor/canvas/canvas_controls.py
@@ -77,15 +77,23 @@ class CanvasControls:
             tile.rect.height = int(tile.rect.height * scale)
             tile.image = pygame.transform.scale(tile.image, tile.rect.size)
 
-    def handle_event(self, event: pygame.event.Event) -> None:
-        """Process Pygame events for canvas controls."""
+    def handle_event(self, event: pygame.event.Event) -> bool:
+        """Process Pygame events for canvas controls.
+
+        Returns True if the event was handled and should not propagate to other
+        handlers.
+        """
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             self._start_drag(event.pos)
+            return self.dragging is not None
         elif event.type == pygame.MOUSEMOTION:
             if self.dragging and event.buttons[0]:
                 self._update_drag(event.pos)
+                return True
         elif event.type == pygame.MOUSEBUTTONUP and event.button == 1:
-            self._end_drag()
+            if self.dragging:
+                self._end_drag()
+                return True
         elif event.type == pygame.KEYDOWN:
             # WASD panning
             if event.key == pygame.K_w:
@@ -101,5 +109,8 @@ class CanvasControls:
             if event.mod & pygame.KMOD_CTRL:
                 if event.key in (pygame.K_EQUALS, pygame.K_KP_PLUS):
                     self._zoom(2.0)
+                    return True
                 elif event.key in (pygame.K_MINUS, pygame.K_KP_MINUS):
                     self._zoom(0.5)
+                    return True
+            return True


### PR DESCRIPTION
## Summary
- hook up `CanvasControls` to EditorApp for panning, zooming and dragging
- return bool from `CanvasControls.handle_event` so we know if an event was used

## Testing
- `python -m py_compile editor_app.py game_core/editor/canvas/canvas_controls.py`

------
https://chatgpt.com/codex/tasks/task_e_6842ab2efec4832db28e8b4912d37e1c