### PR TITLE
Improve canvas navigation and tile placement

### DIFF
--- a/game_core/editor/canvas/tile_placement.py
+++ b/game_core/editor/canvas/tile_placement.py
@@ -15,9 +15,9 @@ class PlacedTile:
     image: pygame.Surface
     rect: pygame.Rect
 
-    def draw(self, surface: pygame.Surface) -> None:
-        """Blit the tile image onto the destination surface."""
-        surface.blit(self.image, self.rect)
+    def draw(self, surface: pygame.Surface, offset: tuple[int, int] = (0, 0)) -> None:
+        """Blit the tile image onto the destination surface respecting the offset."""
+        surface.blit(self.image, self.rect.move(-offset[0], -offset[1]))
 
 
 class TilePlacementManager:
@@ -59,7 +59,7 @@ class TilePlacementManager:
                 self.tiles.remove(tile)
                 break
 
-    def draw(self, surface: pygame.Surface) -> None:
+    def draw(self, surface: pygame.Surface, offset: tuple[int, int] = (0, 0)) -> None:
         """Draw all placed tiles onto the provided surface."""
         for tile in self.tiles:
-            tile.draw(surface)
+            tile.draw(surface, offset)


### PR DESCRIPTION
## Summary
- support unlimited panning by keeping an offset
- draw the grid relative to the offset
- place and erase tiles while dragging
- update dragging and zoom logic to use world coordinates

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842af9958fc832d88f57cff3eb7ca41