### PR TITLE
Enhance canvas navigation

### DIFF
--- a/editor_app.py
+++ b/editor_app.py
@@ -75,7 +75,8 @@ class EditorApp:
                 self.canvas.handle_event(event, self.tab_manager)
 
     def update(self):
-        pass
+        # Allow long-press navigation on the canvas
+        self.canvas_controls.update()
 
     def draw(self):
         self.screen.fill(BACKGROUND_COLOR)


### PR DESCRIPTION
## Summary
- restrict canvas zoom to 100%-300%
- avoid floats in canvas navigation and allow continuous panning
- update editor loop to call new control update method

## Testing
- `python -m py_compile $(git ls-files '*.py' -z | xargs -0)`

------
https://chatgpt.com/codex/tasks/task_e_6842b39dcbd0832dbe5fbc8578786b61