### PR TITLE
Remove canvas drag

### DIFF
--- a/game_core/editor/canvas/canvas.py
+++ b/game_core/editor/canvas/canvas.py
@@ -17,7 +17,6 @@ class Canvas:
         self.grid_size = grid_size
         self.rect = pygame.Rect(x, y, width, height)
         self.offset = [0, 0]
-        self.last_grid_pos: tuple[int, int] | None = None
         self.placement_manager = TilePlacementManager(grid_size)
         self.tilesets = TilesetRepository()
 
@@ -49,38 +48,16 @@ class Canvas:
                         self.placement_manager.add_tile(
                             tile, grid_x, grid_y, self.grid_size, self.grid_size
                         )
-                        self.last_grid_pos = (grid_x, grid_y)
             elif event.button == 3:
                 self.placement_manager.remove_tile_at(grid_x, grid_y)
-                self.last_grid_pos = (grid_x, grid_y)
 
         elif event.type == pygame.MOUSEMOTION and self.rect.collidepoint(event.pos):
-            if event.buttons[0]:
-                grid_x, grid_y = _grid_pos(event.pos)
-                if self.last_grid_pos != (grid_x, grid_y):
-                    tile_index = tab_manager.selected_tile
-                    tileset_index = tab_manager.active_tileset
-                    if tile_index is not None:
-                        tile = self.tilesets.get_tile(tileset_index, tile_index)
-                        if tile is not None:
-                            # Scale the tile for the current zoom level
-                            if tile.get_width() != self.grid_size:
-                                tile = pygame.transform.scale(
-                                    tile, (self.grid_size, self.grid_size)
-                                )
-                            self.placement_manager.add_tile(
-                                tile, grid_x, grid_y, self.grid_size, self.grid_size
-                            )
-                            self.last_grid_pos = (grid_x, grid_y)
-            elif event.buttons[2]:
-                grid_x, grid_y = _grid_pos(event.pos)
-                if self.last_grid_pos != (grid_x, grid_y):
-                    self.placement_manager.remove_tile_at(grid_x, grid_y)
-                    self.last_grid_pos = (grid_x, grid_y)
+            # Intentionally ignore drag events so tiles are only placed or
+            # removed on explicit clicks.
+            pass
 
         elif event.type == pygame.MOUSEBUTTONUP:
-            if event.button in (1, 3):
-                self.last_grid_pos = None
+            pass
 
     def draw(self, surface: pygame.Surface) -> None:
         """Draw the canvas background and grid."""

--- a/game_core/editor/canvas/canvas_controls.py
+++ b/game_core/editor/canvas/canvas_controls.py
@@ -5,64 +5,20 @@ from __future__ import annotations
 import pygame
 
 from .canvas import Canvas
-from .tile_placement import PlacedTile
 
 
 class CanvasControls:
-    """Handle panning, zooming and dragging of canvas tiles."""
+    """Handle panning and zooming of the canvas."""
 
     PAN_SPEED = 10  # pixels moved per key press
 
     def __init__(self, canvas: Canvas) -> None:
         self.canvas = canvas
-        self.dragging: PlacedTile | None = None
-        self.drag_offset = (0, 0)
 
         # Zoom limits based on the initial grid size
         self._base_grid = canvas.grid_size
         self._min_grid = self._base_grid  # 100%
         self._max_grid = self._base_grid * 3  # 300%
-
-    # ------------------------------------------------------------------
-    # Dragging tiles
-    # ------------------------------------------------------------------
-    def _tile_at_pos(self, pos: tuple[int, int]) -> PlacedTile | None:
-        world_pos = (
-            pos[0] - self.canvas.rect.left + self.canvas.offset[0],
-            pos[1] - self.canvas.rect.top + self.canvas.offset[1],
-        )
-        for tile in reversed(self.canvas.placement_manager.tiles):
-            if tile.rect.collidepoint(world_pos):
-                return tile
-        return None
-
-    def _start_drag(self, pos: tuple[int, int]) -> None:
-        tile = self._tile_at_pos(pos)
-        if tile:
-            world_pos = (
-                pos[0] - self.canvas.rect.left + self.canvas.offset[0],
-                pos[1] - self.canvas.rect.top + self.canvas.offset[1],
-            )
-            self.dragging = tile
-            self.drag_offset = (world_pos[0] - tile.rect.x, world_pos[1] - tile.rect.y)
-
-    def _update_drag(self, pos: tuple[int, int]) -> None:
-        if self.dragging:
-            world_pos = (
-                pos[0] - self.canvas.rect.left + self.canvas.offset[0],
-                pos[1] - self.canvas.rect.top + self.canvas.offset[1],
-            )
-            new_x = world_pos[0] - self.drag_offset[0]
-            new_y = world_pos[1] - self.drag_offset[1]
-            self.dragging.rect.topleft = (new_x, new_y)
-
-    def _end_drag(self) -> None:
-        if self.dragging:
-            grid = self.canvas.grid_size
-            snapped_x = (self.dragging.rect.x // grid) * grid
-            snapped_y = (self.dragging.rect.y // grid) * grid
-            self.dragging.rect.topleft = (snapped_x, snapped_y)
-        self.dragging = None
 
     # ------------------------------------------------------------------
     # Canvas navigation
@@ -118,18 +74,7 @@ class CanvasControls:
         Returns True if the event was handled and should not propagate to other
         handlers.
         """
-        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
-            self._start_drag(event.pos)
-            return self.dragging is not None
-        elif event.type == pygame.MOUSEMOTION:
-            if self.dragging and event.buttons[0]:
-                self._update_drag(event.pos)
-                return True
-        elif event.type == pygame.MOUSEBUTTONUP and event.button == 1:
-            if self.dragging:
-                self._end_drag()
-                return True
-        elif event.type == pygame.KEYDOWN:
+        if event.type == pygame.KEYDOWN:
             # WASD/Arrow panning
             if event.key in (pygame.K_w, pygame.K_UP):
                 self._pan(0, -self.PAN_SPEED)
@@ -149,3 +94,4 @@ class CanvasControls:
                     self._zoom(1, 2)
                     return True
             return True
+        return False


### PR DESCRIPTION
## Summary
- disable drag painting in `Canvas`
- remove tile-dragging logic from `CanvasControls`

## Testing
- `python -m py_compile game_core/editor/canvas/canvas.py game_core/editor/canvas/canvas_controls.py`


------
https://chatgpt.com/codex/tasks/task_e_6842e3dc770c832db1ea6b064f617594