### PR TITLE
Enable drag to place tiles

### DIFF
--- a/game_core/editor/canvas/canvas.py
+++ b/game_core/editor/canvas/canvas.py
@@ -52,9 +52,22 @@ class Canvas:
                 self.placement_manager.remove_tile_at(grid_x, grid_y)
 
         elif event.type == pygame.MOUSEMOTION and self.rect.collidepoint(event.pos):
-            # Intentionally ignore drag events so tiles are only placed or
-            # removed on explicit clicks.
-            pass
+            grid_x, grid_y = _grid_pos(event.pos)
+            if event.buttons[0]:  # Left button drag places tiles
+                tile_index = tab_manager.selected_tile
+                tileset_index = tab_manager.active_tileset
+                if tile_index is not None:
+                    tile = self.tilesets.get_tile(tileset_index, tile_index)
+                    if tile is not None and not self.placement_manager.has_tile_at(grid_x, grid_y):
+                        if tile.get_width() != self.grid_size:
+                            tile = pygame.transform.scale(
+                                tile, (self.grid_size, self.grid_size)
+                            )
+                        self.placement_manager.add_tile(
+                            tile, grid_x, grid_y, self.grid_size, self.grid_size
+                        )
+            elif event.buttons[2]:  # Right button drag removes tiles
+                self.placement_manager.remove_tile_at(grid_x, grid_y)
 
         elif event.type == pygame.MOUSEBUTTONUP:
             pass

--- a/game_core/editor/canvas/tile_placement.py
+++ b/game_core/editor/canvas/tile_placement.py
@@ -59,6 +59,11 @@ class TilePlacementManager:
                 self.tiles.remove(tile)
                 break
 
+    def has_tile_at(self, grid_x: int, grid_y: int) -> bool:
+        """Return True if a tile occupies the given grid position."""
+        px, py = self._grid_to_pixels(grid_x, grid_y)
+        return any(tile.rect.collidepoint(px, py) for tile in self.tiles)
+
     def draw(self, surface: pygame.Surface, offset: tuple[int, int] = (0, 0)) -> None:
         """Draw all placed tiles onto the provided surface."""
         for tile in self.tiles:


### PR DESCRIPTION
## Summary
- add ability to check whether a tile already exists on a grid cell
- allow tile placement/removal while dragging the mouse on the editor canvas

## Testing
- `python -m py_compile $(git ls-files '*.py' -z | xargs -0)`

------
https://chatgpt.com/codex/tasks/task_e_6842e71862a4832da2ccad9af0bcdc17