### PR TITLE
Disable tile dragging in map editor

### DIFF
--- a/game_core/editor/canvas/canvas_controls.py
+++ b/game_core/editor/canvas/canvas_controls.py
@@ -5,64 +5,20 @@ from __future__ import annotations
 import pygame
 
 from .canvas import Canvas
-from .tile_placement import PlacedTile
 
 
 class CanvasControls:
-    """Handle panning, zooming and dragging of canvas tiles."""
+    """Handle panning and zooming of the canvas."""
 
     PAN_SPEED = 10  # pixels moved per key press
 
     def __init__(self, canvas: Canvas) -> None:
         self.canvas = canvas
-        self.dragging: PlacedTile | None = None
-        self.drag_offset = (0, 0)
 
         # Zoom limits based on the initial grid size
         self._base_grid = canvas.grid_size
         self._min_grid = self._base_grid  # 100%
         self._max_grid = self._base_grid * 3  # 300%
-
-    # ------------------------------------------------------------------
-    # Dragging tiles
-    # ------------------------------------------------------------------
-    def _tile_at_pos(self, pos: tuple[int, int]) -> PlacedTile | None:
-        world_pos = (
-            pos[0] - self.canvas.rect.left + self.canvas.offset[0],
-            pos[1] - self.canvas.rect.top + self.canvas.offset[1],
-        )
-        for tile in reversed(self.canvas.placement_manager.tiles):
-            if tile.rect.collidepoint(world_pos):
-                return tile
-        return None
-
-    def _start_drag(self, pos: tuple[int, int]) -> None:
-        tile = self._tile_at_pos(pos)
-        if tile:
-            world_pos = (
-                pos[0] - self.canvas.rect.left + self.canvas.offset[0],
-                pos[1] - self.canvas.rect.top + self.canvas.offset[1],
-            )
-            self.dragging = tile
-            self.drag_offset = (world_pos[0] - tile.rect.x, world_pos[1] - tile.rect.y)
-
-    def _update_drag(self, pos: tuple[int, int]) -> None:
-        if self.dragging:
-            world_pos = (
-                pos[0] - self.canvas.rect.left + self.canvas.offset[0],
-                pos[1] - self.canvas.rect.top + self.canvas.offset[1],
-            )
-            new_x = world_pos[0] - self.drag_offset[0]
-            new_y = world_pos[1] - self.drag_offset[1]
-            self.dragging.rect.topleft = (new_x, new_y)
-
-    def _end_drag(self) -> None:
-        if self.dragging:
-            grid = self.canvas.grid_size
-            snapped_x = (self.dragging.rect.x // grid) * grid
-            snapped_y = (self.dragging.rect.y // grid) * grid
-            self.dragging.rect.topleft = (snapped_x, snapped_y)
-        self.dragging = None
 
     # ------------------------------------------------------------------
     # Canvas navigation
@@ -120,18 +76,7 @@ class CanvasControls:
         Returns True if the event was handled and should not propagate to other
         handlers.
         """
-        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
-            self._start_drag(event.pos)
-            return self.dragging is not None
-        elif event.type == pygame.MOUSEMOTION:
-            if self.dragging and event.buttons[0]:
-                self._update_drag(event.pos)
-                return True
-        elif event.type == pygame.MOUSEBUTTONUP and event.button == 1:
-            if self.dragging:
-                self._end_drag()
-                return True
-        elif event.type == pygame.KEYDOWN:
+        if event.type == pygame.KEYDOWN:
             # WASD/Arrow panning
             if event.key in (pygame.K_w, pygame.K_UP):
                 self._pan(0, -self.PAN_SPEED)
@@ -151,3 +96,4 @@ class CanvasControls:
                     self._zoom(1, 2)
                     return True
             return True
+        return False


### PR DESCRIPTION
## Summary
- remove tile drag logic from `CanvasControls`

## Testing
- `python -m py_compile game_core/editor/canvas/canvas_controls.py`
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6842f4eabd88832d88f9ad513d92269b