### PR TITLE
Enable tile replacement on placement

### DIFF
--- a/game_core/editor/canvas/canvas.py
+++ b/game_core/editor/canvas/canvas.py
@@ -58,7 +58,7 @@ class Canvas:
                 tileset_index = tab_manager.active_tileset
                 if tile_index is not None:
                     tile = self.tilesets.get_tile(tileset_index, tile_index)
-                    if tile is not None and not self.placement_manager.has_tile_at(grid_x, grid_y):
+                    if tile is not None:
                         if tile.get_width() != self.grid_size:
                             tile = pygame.transform.scale(
                                 tile, (self.grid_size, self.grid_size)

--- a/game_core/editor/canvas/tile_placement.py
+++ b/game_core/editor/canvas/tile_placement.py
@@ -45,6 +45,11 @@ class TilePlacementManager:
         to span multiple grid cells (e.g. a 48x32 door).
         """
         px, py = self._grid_to_pixels(grid_x, grid_y)
+        # If another tile already occupies this grid position remove it so
+        # the new tile replaces the old one. This allows simple overwriting
+        # behaviour both for single clicks and for click-and-drag placement.
+        self.remove_tile_at(grid_x, grid_y)
+
         width = width or image.get_width()
         height = height or image.get_height()
         rect = pygame.Rect(px, py, width, height)


### PR DESCRIPTION
## Summary
- allow tiles placed on the canvas to overwrite any existing tile
- remove `has_tile_at` check when dragging so dragged tiles replace

## Testing
- `python -m py_compile game_core/editor/canvas/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6842f77e1994832da9baf19cba59a8f1