### PR TITLE
Add tile preview and reposition brush under palettes

### DIFF
--- a/editor_app.py
+++ b/editor_app.py
@@ -80,7 +80,7 @@ class EditorApp:
 
     def draw(self):
         self.screen.fill(BACKGROUND_COLOR)
-        self.canvas.draw(self.screen)
+        self.canvas.draw(self.screen, self.tab_manager)
         self.sidebar.draw(self.screen)
         self.tab_manager.draw(self.screen)
         pygame.display.flip()

--- a/game_core/editor/canvas/canvas.py
+++ b/game_core/editor/canvas/canvas.py
@@ -88,8 +88,8 @@ class Canvas:
         elif event.type == pygame.MOUSEBUTTONUP:
             pass
 
-    def draw(self, surface: pygame.Surface) -> None:
-        """Draw the canvas background and grid."""
+    def draw(self, surface: pygame.Surface, tab_manager: TabManager) -> None:
+        """Draw the canvas background, grid and tile preview."""
         pygame.draw.rect(surface, WHITE, self.rect)
 
         start_x = -self.offset[0] % self.grid_size
@@ -101,3 +101,27 @@ class Canvas:
             pygame.draw.line(surface, LIGHT_GRAY, (self.rect.left, gy), (self.rect.right, gy))
 
         self.placement_manager.draw(surface, tuple(self.offset))
+
+        # --------------------------------------------------------------
+        # Draw preview of the currently selected tile under the cursor
+        # --------------------------------------------------------------
+        mx, my = pygame.mouse.get_pos()
+        if self.rect.collidepoint(mx, my):
+            grid_x = (mx - self.rect.left + self.offset[0]) // self.grid_size
+            grid_y = (my - self.rect.top + self.offset[1]) // self.grid_size
+
+            tile_index = tab_manager.selected_tile
+            tileset_index = tab_manager.active_tileset
+            brush = tab_manager.brush_size
+
+            if tile_index is not None:
+                tile = self.tilesets.get_tile(tileset_index, tile_index)
+                if tile is not None:
+                    if tile.get_width() != self.grid_size:
+                        tile = pygame.transform.scale(tile, (self.grid_size, self.grid_size))
+                    preview = tile.copy()
+                    preview.set_alpha(150)
+                    for bx, by in iter_brush_positions(grid_x, grid_y, brush):
+                        px = bx * self.grid_size - self.offset[0] + self.rect.left
+                        py = by * self.grid_size - self.offset[1] + self.rect.top
+                        surface.blit(preview, (px, py))

--- a/game_core/editor/sidebar/sidebar_tab_manager.py
+++ b/game_core/editor/sidebar/sidebar_tab_manager.py
@@ -88,7 +88,8 @@ class TabManager:
             surface.blit(label, label_rect)
 
         if self.tabs[self.active] == "tiles":
-            self.tileset_palettes.draw(surface)
+            bottom = self.tileset_palettes.draw(surface)
+            self.tileset_brush.set_top(bottom + self.tileset_brush.PADDING)
             self.tileset_brush.draw(surface)
 
 

--- a/game_core/editor/tileset_tab/tileset_brush.py
+++ b/game_core/editor/tileset_tab/tileset_brush.py
@@ -26,15 +26,21 @@ class TilesetBrush:
         self.sidebar_rect = sidebar_rect
         self.selected = 1
         self.font = pygame.font.Font(FONT_PATH, 16)
+        self._top = sidebar_rect.bottom - self.BUTTON_SIZE - self.PADDING
 
     def resize(self, sidebar_rect: pygame.Rect) -> None:
         """Update sidebar reference when resized."""
         self.sidebar_rect = sidebar_rect
+        self._top = sidebar_rect.bottom - self.BUTTON_SIZE - self.PADDING
+
+    def set_top(self, top: int) -> None:
+        """Set the top y-coordinate for the brush buttons."""
+        self._top = top
 
     def _button_rects(self) -> list[pygame.Rect]:
         rects = []
         x = self.sidebar_rect.left + self.PADDING
-        y = self.sidebar_rect.bottom - self.BUTTON_SIZE - self.PADDING
+        y = self._top
         for _ in self.SIZES:
             rects.append(pygame.Rect(x, y, self.BUTTON_SIZE, self.BUTTON_SIZE))
             x += self.BUTTON_SIZE + self.PADDING

--- a/game_core/editor/tileset_tab/tileset_palettes.py
+++ b/game_core/editor/tileset_tab/tileset_palettes.py
@@ -64,8 +64,12 @@ class TilesetPalettes:
             x += self.TAB_WIDTH + self.PADDING
         return rects
 
-    def draw(self, surface: pygame.Surface) -> None:
-        """Draw tileset tabs and the active palette."""
+    def draw(self, surface: pygame.Surface) -> int:
+        """Draw tileset tabs and the active palette.
+
+        Returns the bottom y-coordinate of the palette for layout purposes.
+        """
+        bottom = self.sidebar_rect.top
         for index, rect in enumerate(self._tileset_rects()):
             color = LIGHT_GRAY if index == self.active else DARK_GRAY
             pygame.draw.rect(surface, color, rect)
@@ -78,8 +82,12 @@ class TilesetPalettes:
         if self.active < len(self._drawers):
             drawer = self._drawers[self.active]
             rects = drawer(surface, self.sidebar_rect)
+            if rects:
+                bottom = max(r.bottom for r in rects)
             self.selection_manager.set_tile_rects(self.active, rects)
             self.selection_manager.draw_selection(surface, self.active)
+
+        return bottom
 
 
 __all__ = ["TilesetPalettes"]


### PR DESCRIPTION
## Summary
- show tileset brush directly below palette instead of bottom of sidebar
- preview selected tile under the mouse respecting brush size
- adapt editor drawing to provide tab manager to canvas

## Testing
- `python -m py_compile $(git ls-files '*.py' | tr '\n' '\0' | xargs -0)`
- `mypy game_core editor_app.py` *(fails: No pygame stubs)*

------
https://chatgpt.com/codex/tasks/task_e_6843035fd9c4832dab3186347fe44ef2