### PR TITLE
Add brush shape buttons and fix tile scaling

### DIFF
--- a/game_core/editor/canvas/canvas.py
+++ b/game_core/editor/canvas/canvas.py
@@ -36,6 +36,7 @@ class Canvas:
         if event.type == pygame.MOUSEBUTTONDOWN and self.rect.collidepoint(event.pos):
             grid_x, grid_y = _grid_pos(event.pos)
             brush = tab_manager.brush_size
+            shape = tab_manager.brush_shape
 
             if event.button == 1:
                 tile_index = tab_manager.selected_tile
@@ -43,46 +44,57 @@ class Canvas:
                 if tile_index is not None:
                     tile = self.tilesets.get_tile(tileset_index, tile_index)
                     if tile is not None:
-                        if tile.get_width() != self.grid_size:
+                        if self.grid_size != 16:
+                            factor = self.grid_size / 16
                             tile = pygame.transform.scale(
-                                tile, (self.grid_size, self.grid_size)
+                                tile,
+                                (
+                                    int(tile.get_width() * factor),
+                                    int(tile.get_height() * factor),
+                                ),
                             )
 
-                        for bx, by in iter_brush_positions(grid_x, grid_y, brush):
+                        for bx, by in iter_brush_positions(grid_x, grid_y, brush, shape):
                             self.placement_manager.add_tile(
                                 tile,
                                 bx,
                                 by,
-                                self.grid_size,
-                                self.grid_size,
+                                tile.get_width(),
+                                tile.get_height(),
                             )
             elif event.button == 3:
-                for bx, by in iter_brush_positions(grid_x, grid_y, brush):
+                for bx, by in iter_brush_positions(grid_x, grid_y, brush, shape):
                     self.placement_manager.remove_tile_at(bx, by)
 
         elif event.type == pygame.MOUSEMOTION and self.rect.collidepoint(event.pos):
             grid_x, grid_y = _grid_pos(event.pos)
             brush = tab_manager.brush_size
+            shape = tab_manager.brush_shape
             if event.buttons[0]:  # Left button drag places tiles
                 tile_index = tab_manager.selected_tile
                 tileset_index = tab_manager.active_tileset
                 if tile_index is not None:
                     tile = self.tilesets.get_tile(tileset_index, tile_index)
                     if tile is not None:
-                        if tile.get_width() != self.grid_size:
+                        if self.grid_size != 16:
+                            factor = self.grid_size / 16
                             tile = pygame.transform.scale(
-                                tile, (self.grid_size, self.grid_size)
+                                tile,
+                                (
+                                    int(tile.get_width() * factor),
+                                    int(tile.get_height() * factor),
+                                ),
                             )
-                        for bx, by in iter_brush_positions(grid_x, grid_y, brush):
+                        for bx, by in iter_brush_positions(grid_x, grid_y, brush, shape):
                             self.placement_manager.add_tile(
                                 tile,
                                 bx,
                                 by,
-                                self.grid_size,
-                                self.grid_size,
+                                tile.get_width(),
+                                tile.get_height(),
                             )
             elif event.buttons[2]:  # Right button drag removes tiles
-                for bx, by in iter_brush_positions(grid_x, grid_y, brush):
+                for bx, by in iter_brush_positions(grid_x, grid_y, brush, shape):
                     self.placement_manager.remove_tile_at(bx, by)
 
         elif event.type == pygame.MOUSEBUTTONUP:
@@ -113,15 +125,23 @@ class Canvas:
             tile_index = tab_manager.selected_tile
             tileset_index = tab_manager.active_tileset
             brush = tab_manager.brush_size
+            shape = tab_manager.brush_shape
 
             if tile_index is not None:
                 tile = self.tilesets.get_tile(tileset_index, tile_index)
                 if tile is not None:
-                    if tile.get_width() != self.grid_size:
-                        tile = pygame.transform.scale(tile, (self.grid_size, self.grid_size))
+                    if self.grid_size != 16:
+                        factor = self.grid_size / 16
+                        tile = pygame.transform.scale(
+                            tile,
+                            (
+                                int(tile.get_width() * factor),
+                                int(tile.get_height() * factor),
+                            ),
+                        )
                     preview = tile.copy()
                     preview.set_alpha(150)
-                    for bx, by in iter_brush_positions(grid_x, grid_y, brush):
+                    for bx, by in iter_brush_positions(grid_x, grid_y, brush, shape):
                         px = bx * self.grid_size - self.offset[0] + self.rect.left
                         py = by * self.grid_size - self.offset[1] + self.rect.top
                         surface.blit(preview, (px, py))

--- a/game_core/editor/sidebar/sidebar_tab_manager.py
+++ b/game_core/editor/sidebar/sidebar_tab_manager.py
@@ -46,6 +46,11 @@ class TabManager:
         """Current brush size selected in the tiles tab."""
         return self.tileset_brush.selected
 
+    @property
+    def brush_shape(self) -> str:
+        """Current brush shape selected in the tiles tab."""
+        return self.tileset_brush.shape
+
     def resize(self, sidebar_rect: pygame.Rect) -> None:
         """Update the sidebar reference when resized."""
         self.sidebar_rect = sidebar_rect

--- a/game_core/editor/tileset_tab/tileset_brush.py
+++ b/game_core/editor/tileset_tab/tileset_brush.py
@@ -7,24 +7,34 @@ from ..color_palette import LIGHT_GRAY, DARK_GRAY, SIDEBAR_BORDER, WHITE
 from ..config import FONT_PATH
 
 
-def iter_brush_positions(center_x: int, center_y: int, size: int) -> Iterator[tuple[int, int]]:
-    """Yield grid coordinates affected by a brush of the given size."""
+def iter_brush_positions(
+    center_x: int, center_y: int, size: int, shape: str = "square"
+) -> Iterator[tuple[int, int]]:
+    """Yield grid coordinates affected by a brush of the given size and shape."""
     radius = size // 2
-    for dy in range(-radius, radius + 1):
-        for dx in range(-radius, radius + 1):
-            yield center_x + dx, center_y + dy
+    if shape == "circle":
+        for dy in range(-radius, radius + 1):
+            for dx in range(-radius, radius + 1):
+                if dx * dx + dy * dy <= radius * radius:
+                    yield center_x + dx, center_y + dy
+    else:  # square
+        for dy in range(-radius, radius + 1):
+            for dx in range(-radius, radius + 1):
+                yield center_x + dx, center_y + dy
 
 
 class TilesetBrush:
-    """UI component for choosing brush size when placing tiles."""
+    """UI component for choosing brush size and shape when placing tiles."""
 
     SIZES = [1, 3, 5, 7]
+    SHAPES = ["square", "circle"]
     BUTTON_SIZE = 30
     PADDING = 5
 
     def __init__(self, sidebar_rect: pygame.Rect) -> None:
         self.sidebar_rect = sidebar_rect
         self.selected = 1
+        self.shape = "square"
         self.font = pygame.font.Font(FONT_PATH, 16)
         self._top = sidebar_rect.bottom - self.BUTTON_SIZE - self.PADDING
 
@@ -46,13 +56,26 @@ class TilesetBrush:
             x += self.BUTTON_SIZE + self.PADDING
         return rects
 
+    def _shape_rects(self) -> list[pygame.Rect]:
+        rects = []
+        x = self.sidebar_rect.left + self.PADDING
+        y = self._top + self.BUTTON_SIZE + self.PADDING
+        for _ in self.SHAPES:
+            rects.append(pygame.Rect(x, y, self.BUTTON_SIZE, self.BUTTON_SIZE))
+            x += self.BUTTON_SIZE + self.PADDING
+        return rects
+
     def handle_event(self, event: pygame.event.Event) -> None:
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             mx, my = event.pos
             for size, rect in zip(self.SIZES, self._button_rects()):
                 if rect.collidepoint(mx, my):
                     self.selected = size
-                    break
+                    return
+            for shape, rect in zip(self.SHAPES, self._shape_rects()):
+                if rect.collidepoint(mx, my):
+                    self.shape = shape
+                    return
 
     def draw(self, surface: pygame.Surface) -> None:
         for size, rect in zip(self.SIZES, self._button_rects()):
@@ -61,6 +84,16 @@ class TilesetBrush:
             pygame.draw.rect(surface, SIDEBAR_BORDER, rect, 1)
 
             label = self.font.render(f"{size}x{size}", True, WHITE)
+            label_rect = label.get_rect(center=rect.center)
+            surface.blit(label, label_rect)
+
+        for shape, rect in zip(self.SHAPES, self._shape_rects()):
+            color = LIGHT_GRAY if shape == self.shape else DARK_GRAY
+            pygame.draw.rect(surface, color, rect)
+            pygame.draw.rect(surface, SIDEBAR_BORDER, rect, 1)
+
+            text = "O" if shape == "circle" else "[]"
+            label = self.font.render(text, True, WHITE)
             label_rect = label.get_rect(center=rect.center)
             surface.blit(label, label_rect)
 


### PR DESCRIPTION
## Summary
- add circle brush logic and shape buttons in `TilesetBrush`
- expose `brush_shape` in the sidebar manager
- support square/circle brushes when placing tiles
- scale special tiles according to zoom level
- fix duplicate variable assignment

## Testing
- `find . -name '*.py' | while read f; do python3 -m py_compile "$f" || exit 1; done`

------
https://chatgpt.com/codex/tasks/task_e_6843097ebd44832db926eb40a642aa32