### PR TITLE
Add tileset layer management component

### DIFF
--- a/editor_app.py
+++ b/editor_app.py
@@ -40,7 +40,11 @@ class EditorApp:
         self.sidebar = Sidebar(self.height, self.width - SIDEBAR_WIDTH)
         self.canvas = Canvas(self.width - SIDEBAR_WIDTH, self.height)
         self.canvas_controls = CanvasControls(self.canvas)
-        self.tab_manager = TabManager(["tiles", "browse", "save"], self.sidebar.rect)
+        self.tab_manager = TabManager(
+            ["tiles", "browse", "save"],
+            self.sidebar.rect,
+            self.canvas.placement_manager,
+        )
 
     def toggle_fullscreen(self) -> None:
         """Toggle fullscreen mode."""

--- a/game_core/editor/canvas/canvas.py
+++ b/game_core/editor/canvas/canvas.py
@@ -38,6 +38,7 @@ class Canvas:
             grid_x, grid_y = _grid_pos(event.pos)
             brush = tab_manager.brush_size
             shape = tab_manager.brush_shape
+            layer = tab_manager.active_layer
 
             if event.button == 1:
                 tile_index = tab_manager.selected_tile
@@ -62,15 +63,17 @@ class Canvas:
                                 by,
                                 tile.get_width(),
                                 tile.get_height(),
+                                layer,
                             )
             elif event.button == 3:
                 for bx, by in iter_brush_positions(grid_x, grid_y, brush, shape):
-                    self.placement_manager.remove_tile_at(bx, by)
+                    self.placement_manager.remove_tile_at(bx, by, layer)
 
         elif event.type == pygame.MOUSEMOTION and self.rect.collidepoint(event.pos):
             grid_x, grid_y = _grid_pos(event.pos)
             brush = tab_manager.brush_size
             shape = tab_manager.brush_shape
+            layer = tab_manager.active_layer
             if event.buttons[0]:  # Left button drag places tiles
                 tile_index = tab_manager.selected_tile
                 tileset_index = tab_manager.active_tileset
@@ -93,10 +96,11 @@ class Canvas:
                                 by,
                                 tile.get_width(),
                                 tile.get_height(),
+                                layer,
                             )
             elif event.buttons[2]:  # Right button drag removes tiles
                 for bx, by in iter_brush_positions(grid_x, grid_y, brush, shape):
-                    self.placement_manager.remove_tile_at(bx, by)
+                    self.placement_manager.remove_tile_at(bx, by, layer)
 
         elif event.type == pygame.MOUSEBUTTONUP:
             pass

--- a/game_core/editor/canvas/tile_placement.py
+++ b/game_core/editor/canvas/tile_placement.py
@@ -22,15 +22,21 @@ class PlacedTile:
 
 
 class TilePlacementManager:
-    """Manage placement of tiles within a canvas grid."""
+    """Manage placement of tiles within a canvas grid across multiple layers."""
 
     def __init__(self, grid_size: int = 16) -> None:
         self.grid_size = grid_size
-        self.tiles: List[PlacedTile] = []
+        # Each element in ``layers`` is a list of ``PlacedTile`` objects.
+        self.layers: List[List[PlacedTile]] = [[]]
 
     def _grid_to_pixels(self, x: int, y: int) -> tuple[int, int]:
         """Convert grid coordinates to pixel coordinates."""
         return x * self.grid_size, y * self.grid_size
+
+    def ensure_layer(self, index: int) -> None:
+        """Ensure that the layer list is long enough for ``index``."""
+        while len(self.layers) <= index:
+            self.layers.append([])
 
     def add_tile(
         self,
@@ -39,38 +45,59 @@ class TilePlacementManager:
         grid_y: int,
         width: int | None = None,
         height: int | None = None,
+        layer: int = 0,
     ) -> pygame.Rect:
         """Place a tile at the given grid coordinates.
 
         The width and height default to the image's size, allowing special tiles
         to span multiple grid cells (e.g. a 48x32 door).
         """
+        self.ensure_layer(layer)
         px, py = self._grid_to_pixels(grid_x, grid_y)
-        # If another tile already occupies this grid position remove it so
-        # the new tile replaces the old one. This allows simple overwriting
-        # behaviour both for single clicks and for click-and-drag placement.
-        self.remove_tile_at(grid_x, grid_y)
+        # Overwrite any tile already occupying this grid position on the same layer.
+        self.remove_tile_at(grid_x, grid_y, layer)
 
         width = width or image.get_width()
         height = height or image.get_height()
         rect = pygame.Rect(px, py, width, height)
-        self.tiles.append(PlacedTile(image, rect))
+        self.layers[layer].append(PlacedTile(image, rect))
         return rect
 
-    def remove_tile_at(self, grid_x: int, grid_y: int) -> None:
-        """Remove the first tile found at the given grid position."""
+    def remove_tile_at(self, grid_x: int, grid_y: int, layer: int = 0) -> None:
+        """Remove the first tile found at the given grid position on a layer."""
+        if layer >= len(self.layers):
+            return
         px, py = self._grid_to_pixels(grid_x, grid_y)
-        for tile in list(self.tiles):
+        for tile in list(self.layers[layer]):
             if tile.rect.collidepoint(px, py):
-                self.tiles.remove(tile)
+                self.layers[layer].remove(tile)
                 break
 
-    def has_tile_at(self, grid_x: int, grid_y: int) -> bool:
+    def has_tile_at(self, grid_x: int, grid_y: int, layer: int | None = None) -> bool:
         """Return True if a tile occupies the given grid position."""
         px, py = self._grid_to_pixels(grid_x, grid_y)
-        return any(tile.rect.collidepoint(px, py) for tile in self.tiles)
+        if layer is None:
+            return any(
+                tile.rect.collidepoint(px, py)
+                for layer_tiles in self.layers
+                for tile in layer_tiles
+            )
+        if 0 <= layer < len(self.layers):
+            return any(tile.rect.collidepoint(px, py) for tile in self.layers[layer])
+        return False
 
     def draw(self, surface: pygame.Surface, offset: tuple[int, int] = (0, 0)) -> None:
         """Draw all placed tiles onto the provided surface."""
-        for tile in self.tiles:
-            tile.draw(surface, offset)
+        for layer_tiles in self.layers:
+            for tile in layer_tiles:
+                tile.draw(surface, offset)
+
+    # Layer management -------------------------------------------------
+    def add_layer(self) -> None:
+        """Append a new empty layer."""
+        self.layers.append([])
+
+    def delete_layer(self, index: int) -> None:
+        """Delete a layer and all its tiles if multiple layers exist."""
+        if 0 <= index < len(self.layers) and len(self.layers) > 1:
+            self.layers.pop(index)

--- a/game_core/editor/tileset_tab/tileset_layer.py
+++ b/game_core/editor/tileset_tab/tileset_layer.py
@@ -1,0 +1,134 @@
+"""Tile layer management component for the editor."""
+# Provides simple controls for creating, deleting and selecting layers.
+
+from __future__ import annotations
+
+from typing import List
+import pygame
+
+from ..color_palette import LIGHT_GRAY, DARK_GRAY, SIDEBAR_BORDER, WHITE
+from ..config import FONT_PATH
+
+
+class TilesetLayers:
+    """UI component for managing tile layers inside the sidebar."""
+
+    LAYER_HEIGHT = 25
+    LAYER_WIDTH = 100
+    PADDING = 5
+    BUTTON_SIZE = 25
+
+    def __init__(self, sidebar_rect: pygame.Rect) -> None:
+        self.sidebar_rect = sidebar_rect
+        self.font = pygame.font.Font(FONT_PATH, 16)
+        self.layers: List[str] = ["Layer 1"]
+        self.active = 0
+        self._left = sidebar_rect.left + self.PADDING
+        self._top = sidebar_rect.top + self.PADDING
+
+    def resize(self, sidebar_rect: pygame.Rect) -> None:
+        """Update sidebar reference when resized."""
+        self.sidebar_rect = sidebar_rect
+        self._left = sidebar_rect.left + self.PADDING
+
+    def set_top(self, top: int) -> None:
+        """Set the top y-coordinate for the layer buttons."""
+        self._top = top
+
+    def set_position(self, left: int, top: int) -> None:
+        """Set the x/y position for the component."""
+        self._left = left
+        self._top = top
+
+    def add_layer(self, name: str | None = None) -> None:
+        """Create a new layer and make it active."""
+        name = name or f"Layer {len(self.layers) + 1}"
+        self.layers.append(name)
+        self.active = len(self.layers) - 1
+
+    def delete_layer(self, index: int | None = None) -> int | None:
+        """Remove a layer by index or the active layer if unspecified."""
+        if len(self.layers) <= 1:
+            return None
+        if index is None:
+            index = self.active
+        if 0 <= index < len(self.layers):
+            self.layers.pop(index)
+            if self.active >= len(self.layers):
+                self.active = len(self.layers) - 1
+            return index
+        return None
+
+    def set_active(self, index: int) -> None:
+        """Set which layer new tiles are placed on."""
+        if 0 <= index < len(self.layers):
+            self.active = index
+
+    def _layer_rects(self) -> List[pygame.Rect]:
+        rects = []
+        x = self._left
+        y = self._top
+        for _ in self.layers:
+            rects.append(pygame.Rect(x, y, self.LAYER_WIDTH, self.LAYER_HEIGHT))
+            y += self.LAYER_HEIGHT + self.PADDING
+        return rects
+
+    def _add_rect(self) -> pygame.Rect:
+        y = self._top + (self.LAYER_HEIGHT + self.PADDING) * len(self.layers)
+        return pygame.Rect(self._left, y, self.BUTTON_SIZE, self.BUTTON_SIZE)
+
+    def _delete_rect(self) -> pygame.Rect:
+        y = self._top + (self.LAYER_HEIGHT + self.PADDING) * len(self.layers)
+        return pygame.Rect(
+            self._left + self.BUTTON_SIZE + self.PADDING,
+            y,
+            self.BUTTON_SIZE,
+            self.BUTTON_SIZE,
+        )
+
+    def handle_event(self, event: pygame.event.Event) -> str | tuple[str, int] | None:
+        """Handle mouse clicks to change the active layer.
+
+        Returns "add" or "delete" when a layer is created or removed.
+        """
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            mx, my = event.pos
+            if self._add_rect().collidepoint(mx, my):
+                self.add_layer()
+                return "add"
+            if self._delete_rect().collidepoint(mx, my):
+                removed = self.delete_layer()
+                if removed is not None:
+                    return "delete", removed
+                return None
+            for index, rect in enumerate(self._layer_rects()):
+                if rect.collidepoint(mx, my):
+                    self.active = index
+                    break
+        return None
+
+    def draw(self, surface: pygame.Surface) -> None:
+        """Draw the layer buttons."""
+        for index, rect in enumerate(self._layer_rects()):
+            color = LIGHT_GRAY if index == self.active else DARK_GRAY
+            pygame.draw.rect(surface, color, rect)
+            pygame.draw.rect(surface, SIDEBAR_BORDER, rect, 1)
+
+            label = self.font.render(self.layers[index], True, WHITE)
+            label_rect = label.get_rect(center=rect.center)
+            surface.blit(label, label_rect)
+
+        add_rect = self._add_rect()
+        del_rect = self._delete_rect()
+        pygame.draw.rect(surface, DARK_GRAY, add_rect)
+        pygame.draw.rect(surface, SIDEBAR_BORDER, add_rect, 1)
+        pygame.draw.rect(surface, DARK_GRAY, del_rect)
+        pygame.draw.rect(surface, SIDEBAR_BORDER, del_rect, 1)
+
+        plus = self.font.render("+", True, WHITE)
+        minus = self.font.render("-", True, WHITE)
+        surface.blit(plus, plus.get_rect(center=add_rect.center))
+        surface.blit(minus, minus.get_rect(center=del_rect.center))
+
+
+__all__ = ["TilesetLayers"]


### PR DESCRIPTION
## Summary
- implement `TilesetLayers` UI component
- integrate layers with `TabManager` and canvas placement
- support adding/removing layers via UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843f3061350832d92c6834d4518eccc