### PR TITLE
Add scrollable container for layer list

### DIFF
--- a/game_core/editor/sidebar/sidebar_tab_manager.py
+++ b/game_core/editor/sidebar/sidebar_tab_manager.py
@@ -69,6 +69,14 @@ class TabManager:
         self.tileset_palettes.resize(sidebar_rect)
         self.tileset_brush.resize(sidebar_rect)
         self.tileset_layers.resize(sidebar_rect)
+        self.tileset_layers.set_container(
+            pygame.Rect(
+                self.sidebar_rect.left + self.tileset_brush.PADDING,
+                sidebar_rect.top,
+                self.tileset_layers.LAYER_WIDTH,
+                sidebar_rect.height,
+            )
+        )
 
     def handle_event(self, event: pygame.event.Event) -> None:
         """Handle mouse clicks to switch tabs."""
@@ -127,7 +135,15 @@ class TabManager:
                 + width
                 + self.tileset_brush.PADDING
             )
-            self.tileset_layers.set_position(layer_left, brush_top)
+            container_height = self.sidebar_rect.bottom - brush_top - self.PADDING
+            self.tileset_layers.set_container(
+                pygame.Rect(
+                    layer_left,
+                    brush_top,
+                    self.tileset_layers.LAYER_WIDTH,
+                    container_height,
+                )
+            )
             self.tileset_layers.draw(surface)
 
 

--- a/game_core/editor/tileset_tab/tileset_layer.py
+++ b/game_core/editor/tileset_tab/tileset_layer.py
@@ -23,22 +23,43 @@ class TilesetLayers:
         self.font = pygame.font.Font(FONT_PATH, 16)
         self.layers: List[str] = ["Layer 1"]
         self.active = 0
-        self._left = sidebar_rect.left + self.PADDING
-        self._top = sidebar_rect.top + self.PADDING
+        # Container the component is drawn within
+        self.container_rect = sidebar_rect.copy()
+        self.scroll_offset = 0
+        self._left = self.container_rect.left + self.PADDING
+        self._top = self.container_rect.top + self.PADDING
 
     def resize(self, sidebar_rect: pygame.Rect) -> None:
         """Update sidebar reference when resized."""
         self.sidebar_rect = sidebar_rect
-        self._left = sidebar_rect.left + self.PADDING
+        self.container_rect = sidebar_rect.copy()
+        self._left = self.container_rect.left + self.PADDING
 
     def set_top(self, top: int) -> None:
         """Set the top y-coordinate for the layer buttons."""
-        self._top = top
+        self.container_rect.top = top
+        self._top = self.container_rect.top + self.PADDING
 
     def set_position(self, left: int, top: int) -> None:
         """Set the x/y position for the component."""
-        self._left = left
-        self._top = top
+        self.container_rect.topleft = (left, top)
+        self._left = self.container_rect.left + self.PADDING
+        self._top = self.container_rect.top + self.PADDING
+
+    def set_container(self, rect: pygame.Rect) -> None:
+        """Define the container rectangle for the layer list."""
+        self.container_rect = rect
+        self._left = self.container_rect.left + self.PADDING
+        self._top = self.container_rect.top + self.PADDING
+
+    def scroll(self, amount: int) -> None:
+        """Scroll the layer list vertically by ``amount`` pixels."""
+        max_scroll = max(
+            0,
+            (self.LAYER_HEIGHT + self.PADDING) * (len(self.layers) + 1)
+            - self.container_rect.height,
+        )
+        self.scroll_offset = max(0, min(self.scroll_offset + amount, max_scroll))
 
     def add_layer(self, name: str | None = None) -> None:
         """Create a new layer and make it active."""
@@ -67,18 +88,18 @@ class TilesetLayers:
     def _layer_rects(self) -> List[pygame.Rect]:
         rects = []
         x = self._left
-        y = self._top
+        y = self._top - self.scroll_offset
         for _ in self.layers:
             rects.append(pygame.Rect(x, y, self.LAYER_WIDTH, self.LAYER_HEIGHT))
             y += self.LAYER_HEIGHT + self.PADDING
         return rects
 
     def _add_rect(self) -> pygame.Rect:
-        y = self._top + (self.LAYER_HEIGHT + self.PADDING) * len(self.layers)
+        y = self._top + (self.LAYER_HEIGHT + self.PADDING) * len(self.layers) - self.scroll_offset
         return pygame.Rect(self._left, y, self.BUTTON_SIZE, self.BUTTON_SIZE)
 
     def _delete_rect(self) -> pygame.Rect:
-        y = self._top + (self.LAYER_HEIGHT + self.PADDING) * len(self.layers)
+        y = self._top + (self.LAYER_HEIGHT + self.PADDING) * len(self.layers) - self.scroll_offset
         return pygame.Rect(
             self._left + self.BUTTON_SIZE + self.PADDING,
             y,
@@ -93,6 +114,8 @@ class TilesetLayers:
         """
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             mx, my = event.pos
+            if not self.container_rect.collidepoint(mx, my):
+                return None
             if self._add_rect().collidepoint(mx, my):
                 self.add_layer()
                 return "add"
@@ -105,10 +128,21 @@ class TilesetLayers:
                 if rect.collidepoint(mx, my):
                     self.active = index
                     break
+        elif event.type == pygame.MOUSEBUTTONDOWN and event.button in (4, 5):
+            mx, my = pygame.mouse.get_pos()
+            if self.container_rect.collidepoint(mx, my):
+                direction = -1 if event.button == 4 else 1
+                self.scroll(direction * (self.LAYER_HEIGHT + self.PADDING))
+        elif event.type == pygame.MOUSEWHEEL:
+            mx, my = pygame.mouse.get_pos()
+            if self.container_rect.collidepoint(mx, my):
+                self.scroll(-event.y * (self.LAYER_HEIGHT + self.PADDING))
         return None
 
     def draw(self, surface: pygame.Surface) -> None:
         """Draw the layer buttons."""
+        old_clip = surface.get_clip()
+        surface.set_clip(self.container_rect)
         for index, rect in enumerate(self._layer_rects()):
             color = LIGHT_GRAY if index == self.active else DARK_GRAY
             pygame.draw.rect(surface, color, rect)
@@ -129,6 +163,7 @@ class TilesetLayers:
         minus = self.font.render("-", True, WHITE)
         surface.blit(plus, plus.get_rect(center=add_rect.center))
         surface.blit(minus, minus.get_rect(center=del_rect.center))
+        surface.set_clip(old_clip)
 
 
 __all__ = ["TilesetLayers"]


### PR DESCRIPTION
## Summary
- wrap layer management UI in a container
- allow mouse wheel scrolling through layers
- update sidebar tab manager to size container on draw/resize

## Testing
- `python -m py_compile editor_app.py game_core/editor/sidebar/sidebar_tab_manager.py game_core/editor/tileset_tab/tileset_layer.py`

------
https://chatgpt.com/codex/tasks/task_e_684402e88788832d851ef7804c449bc4