### PR TITLE
Add scrollable container for layer list

### DIFF
--- a/game_core/editor/sidebar/sidebar_tab_manager.py
+++ b/game_core/editor/sidebar/sidebar_tab_manager.py
@@ -113,21 +113,25 @@ class TabManager:
 
         if self.tabs[self.active] == "tiles":
             bottom = self.tileset_palettes.draw(surface)
-            brush_top = bottom + self.tileset_brush.PADDING
-            self.tileset_brush.set_top(brush_top)
+            brush_rect = pygame.Rect(
+                self.sidebar_rect.left + self.tileset_brush.PADDING,
+                bottom + self.tileset_brush.PADDING,
+                self.tileset_brush.container_rect.width,
+                self.tileset_brush.container_rect.height,
+            )
+            self.tileset_brush.set_container(brush_rect)
             self.tileset_brush.draw(surface)
 
-            width = (
-                self.tileset_brush.BUTTON_SIZE * len(self.tileset_brush.SIZES)
-                + self.tileset_brush.PADDING * (len(self.tileset_brush.SIZES) - 1)
+            layer_left = brush_rect.right + self.tileset_brush.PADDING
+            container_height = self.sidebar_rect.bottom - brush_rect.top - self.PADDING
+            self.tileset_layers.set_container(
+                pygame.Rect(
+                    layer_left,
+                    brush_rect.top,
+                    self.tileset_layers.LAYER_WIDTH,
+                    container_height,
+                )
             )
-            layer_left = (
-                self.sidebar_rect.left
-                + self.tileset_brush.PADDING
-                + width
-                + self.tileset_brush.PADDING
-            )
-            self.tileset_layers.set_position(layer_left, brush_top)
             self.tileset_layers.draw(surface)
 
 

--- a/game_core/editor/tileset_tab/tileset_brush.py
+++ b/game_core/editor/tileset_tab/tileset_brush.py
@@ -1,6 +1,6 @@
 """UI component for choosing brush size and shape."""
 from __future__ import annotations
-# Provides brush button layout and logic.
+# Provides brush button layout and logic wrapped in a bordered container.
 
 import pygame
 from typing import Iterator
@@ -38,20 +38,42 @@ class TilesetBrush:
         self.selected = 1
         self.shape = "square"
         self.font = pygame.font.Font(FONT_PATH, 16)
-        self._top = sidebar_rect.bottom - self.BUTTON_SIZE - self.PADDING
+
+        # Container rect defines the outer box drawn around the buttons
+        width_buttons = self.BUTTON_SIZE * len(self.SIZES) + self.PADDING * (len(self.SIZES) - 1)
+        width_shapes = self.BUTTON_SIZE * len(self.SHAPES) + self.PADDING * (len(self.SHAPES) - 1)
+        container_width = max(width_buttons, width_shapes) + self.PADDING * 2
+        container_height = self.BUTTON_SIZE * 2 + self.PADDING * 3
+        self.container_rect = pygame.Rect(sidebar_rect.left + self.PADDING, sidebar_rect.top, container_width, container_height)
+
+        # Button coordinates relative to the container
+        self._left = self.container_rect.left + self.PADDING
+        self._top = self.container_rect.top + self.PADDING
 
     def resize(self, sidebar_rect: pygame.Rect) -> None:
         """Update sidebar reference when resized."""
         self.sidebar_rect = sidebar_rect
-        self._top = sidebar_rect.bottom - self.BUTTON_SIZE - self.PADDING
+        width_buttons = self.BUTTON_SIZE * len(self.SIZES) + self.PADDING * (len(self.SIZES) - 1)
+        width_shapes = self.BUTTON_SIZE * len(self.SHAPES) + self.PADDING * (len(self.SHAPES) - 1)
+        self.container_rect.width = max(width_buttons, width_shapes) + self.PADDING * 2
+        self.container_rect.height = self.BUTTON_SIZE * 2 + self.PADDING * 3
+        self.container_rect.left = sidebar_rect.left + self.PADDING
 
     def set_top(self, top: int) -> None:
         """Set the top y-coordinate for the brush buttons."""
+        self.container_rect.top = top - self.PADDING
         self._top = top
+        self._left = self.container_rect.left + self.PADDING
+
+    def set_container(self, rect: pygame.Rect) -> None:
+        """Define the container rectangle for the brush."""
+        self.container_rect = rect
+        self._left = rect.left + self.PADDING
+        self._top = rect.top + self.PADDING
 
     def _button_rects(self) -> list[pygame.Rect]:
         rects = []
-        x = self.sidebar_rect.left + self.PADDING
+        x = self._left
         y = self._top
         for _ in self.SIZES:
             rects.append(pygame.Rect(x, y, self.BUTTON_SIZE, self.BUTTON_SIZE))
@@ -60,7 +82,7 @@ class TilesetBrush:
 
     def _shape_rects(self) -> list[pygame.Rect]:
         rects = []
-        x = self.sidebar_rect.left + self.PADDING
+        x = self._left
         y = self._top + self.BUTTON_SIZE + self.PADDING
         for _ in self.SHAPES:
             rects.append(pygame.Rect(x, y, self.BUTTON_SIZE, self.BUTTON_SIZE))
@@ -70,6 +92,8 @@ class TilesetBrush:
     def handle_event(self, event: pygame.event.Event) -> None:
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             mx, my = event.pos
+            if not self.container_rect.collidepoint(mx, my):
+                return
             for size, rect in zip(self.SIZES, self._button_rects()):
                 if rect.collidepoint(mx, my):
                     self.selected = size
@@ -80,6 +104,8 @@ class TilesetBrush:
                     return
 
     def draw(self, surface: pygame.Surface) -> None:
+        pygame.draw.rect(surface, DARK_GRAY, self.container_rect)
+        pygame.draw.rect(surface, SIDEBAR_BORDER, self.container_rect, 1)
         for size, rect in zip(self.SIZES, self._button_rects()):
             color = LIGHT_GRAY if size == self.selected else DARK_GRAY
             pygame.draw.rect(surface, color, rect)

--- a/game_core/editor/tileset_tab/tileset_layer.py
+++ b/game_core/editor/tileset_tab/tileset_layer.py
@@ -23,22 +23,43 @@ class TilesetLayers:
         self.font = pygame.font.Font(FONT_PATH, 16)
         self.layers: List[str] = ["Layer 1"]
         self.active = 0
-        self._left = sidebar_rect.left + self.PADDING
-        self._top = sidebar_rect.top + self.PADDING
+        # Container the component is drawn within
+        self.container_rect = sidebar_rect.copy()
+        self.scroll_offset = 0
+        self._left = self.container_rect.left + self.PADDING
+        self._top = self.container_rect.top + self.PADDING
 
     def resize(self, sidebar_rect: pygame.Rect) -> None:
         """Update sidebar reference when resized."""
         self.sidebar_rect = sidebar_rect
-        self._left = sidebar_rect.left + self.PADDING
+        self.container_rect = sidebar_rect.copy()
+        self._left = self.container_rect.left + self.PADDING
 
     def set_top(self, top: int) -> None:
         """Set the top y-coordinate for the layer buttons."""
-        self._top = top
+        self.container_rect.top = top
+        self._top = self.container_rect.top + self.PADDING
 
     def set_position(self, left: int, top: int) -> None:
         """Set the x/y position for the component."""
-        self._left = left
-        self._top = top
+        self.container_rect.topleft = (left, top)
+        self._left = self.container_rect.left + self.PADDING
+        self._top = self.container_rect.top + self.PADDING
+
+    def set_container(self, rect: pygame.Rect) -> None:
+        """Define the container rectangle for the layer list."""
+        self.container_rect = rect
+        self._left = self.container_rect.left + self.PADDING
+        self._top = self.container_rect.top + self.PADDING
+
+    def scroll(self, amount: int) -> None:
+        """Scroll the layer list vertically by ``amount`` pixels."""
+        max_scroll = max(
+            0,
+            (self.LAYER_HEIGHT + self.PADDING) * (len(self.layers) + 1)
+            - self.container_rect.height,
+        )
+        self.scroll_offset = max(0, min(self.scroll_offset + amount, max_scroll))
 
     def add_layer(self, name: str | None = None) -> None:
         """Create a new layer and make it active."""
@@ -67,18 +88,18 @@ class TilesetLayers:
     def _layer_rects(self) -> List[pygame.Rect]:
         rects = []
         x = self._left
-        y = self._top
+        y = self._top - self.scroll_offset
         for _ in self.layers:
             rects.append(pygame.Rect(x, y, self.LAYER_WIDTH, self.LAYER_HEIGHT))
             y += self.LAYER_HEIGHT + self.PADDING
         return rects
 
     def _add_rect(self) -> pygame.Rect:
-        y = self._top + (self.LAYER_HEIGHT + self.PADDING) * len(self.layers)
+        y = self._top + (self.LAYER_HEIGHT + self.PADDING) * len(self.layers) - self.scroll_offset
         return pygame.Rect(self._left, y, self.BUTTON_SIZE, self.BUTTON_SIZE)
 
     def _delete_rect(self) -> pygame.Rect:
-        y = self._top + (self.LAYER_HEIGHT + self.PADDING) * len(self.layers)
+        y = self._top + (self.LAYER_HEIGHT + self.PADDING) * len(self.layers) - self.scroll_offset
         return pygame.Rect(
             self._left + self.BUTTON_SIZE + self.PADDING,
             y,
@@ -93,6 +114,8 @@ class TilesetLayers:
         """
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             mx, my = event.pos
+            if not self.container_rect.collidepoint(mx, my):
+                return None
             if self._add_rect().collidepoint(mx, my):
                 self.add_layer()
                 return "add"
@@ -105,10 +128,23 @@ class TilesetLayers:
                 if rect.collidepoint(mx, my):
                     self.active = index
                     break
+        elif event.type == pygame.MOUSEBUTTONDOWN and event.button in (4, 5):
+            mx, my = pygame.mouse.get_pos()
+            if self.container_rect.collidepoint(mx, my):
+                direction = -1 if event.button == 4 else 1
+                self.scroll(direction * (self.LAYER_HEIGHT + self.PADDING))
+        elif event.type == pygame.MOUSEWHEEL:
+            mx, my = pygame.mouse.get_pos()
+            if self.container_rect.collidepoint(mx, my):
+                self.scroll(-event.y * (self.LAYER_HEIGHT + self.PADDING))
         return None
 
     def draw(self, surface: pygame.Surface) -> None:
         """Draw the layer buttons."""
+        pygame.draw.rect(surface, DARK_GRAY, self.container_rect)
+        pygame.draw.rect(surface, SIDEBAR_BORDER, self.container_rect, 1)
+        old_clip = surface.get_clip()
+        surface.set_clip(self.container_rect.inflate(-1, -1))
         for index, rect in enumerate(self._layer_rects()):
             color = LIGHT_GRAY if index == self.active else DARK_GRAY
             pygame.draw.rect(surface, color, rect)
@@ -129,6 +165,7 @@ class TilesetLayers:
         minus = self.font.render("-", True, WHITE)
         surface.blit(plus, plus.get_rect(center=add_rect.center))
         surface.blit(minus, minus.get_rect(center=del_rect.center))
+        surface.set_clip(old_clip)
 
 
 __all__ = ["TilesetLayers"]


### PR DESCRIPTION
## Summary
- wrap layer management UI in a container
- allow mouse wheel scrolling through layers
- add bordered container for brush UI
- update tab manager to position brush and layer containers

## Testing
- `python -m py_compile editor_app.py game_core/editor/sidebar/sidebar_tab_manager.py game_core/editor/tileset_tab/tileset_layer.py game_core/editor/tileset_tab/tileset_brush.py`


------
https://chatgpt.com/codex/tasks/task_e_684402e88788832d851ef7804c449bc4