### PR TITLE
Add scrollable container for layer list

### DIFF
--- a/game_core/editor/sidebar/sidebar_tab_manager.py
+++ b/game_core/editor/sidebar/sidebar_tab_manager.py
@@ -113,21 +113,28 @@ class TabManager:
 
         if self.tabs[self.active] == "tiles":
             bottom = self.tileset_palettes.draw(surface)
-            brush_top = bottom + self.tileset_brush.PADDING
-            self.tileset_brush.set_top(brush_top)
+            available = self.sidebar_rect.width - self.tileset_brush.PADDING * 3
+            box_width = available // 2
+            brush_rect = pygame.Rect(
+                self.sidebar_rect.left + self.tileset_brush.PADDING,
+                bottom + self.tileset_brush.PADDING,
+                box_width,
+                self.tileset_brush.container_rect.height,
+            )
+            self.tileset_brush.set_container(brush_rect)
             self.tileset_brush.draw(surface)
 
-            width = (
-                self.tileset_brush.BUTTON_SIZE * len(self.tileset_brush.SIZES)
-                + self.tileset_brush.PADDING * (len(self.tileset_brush.SIZES) - 1)
+            layer_left = brush_rect.right + self.tileset_brush.PADDING
+            max_height = self.sidebar_rect.bottom - brush_rect.top - self.PADDING
+            container_height = min(box_width, max_height)
+            self.tileset_layers.set_container(
+                pygame.Rect(
+                    layer_left,
+                    brush_rect.top,
+                    box_width,
+                    container_height,
+                )
             )
-            layer_left = (
-                self.sidebar_rect.left
-                + self.tileset_brush.PADDING
-                + width
-                + self.tileset_brush.PADDING
-            )
-            self.tileset_layers.set_position(layer_left, brush_top)
             self.tileset_layers.draw(surface)
 
 

--- a/game_core/editor/tileset_tab/tileset_brush.py
+++ b/game_core/editor/tileset_tab/tileset_brush.py
@@ -1,6 +1,6 @@
 """UI component for choosing brush size and shape."""
 from __future__ import annotations
-# Provides brush button layout and logic.
+# Provides brush button layout and logic wrapped in a bordered container.
 
 import pygame
 from typing import Iterator
@@ -38,20 +38,42 @@ class TilesetBrush:
         self.selected = 1
         self.shape = "square"
         self.font = pygame.font.Font(FONT_PATH, 16)
-        self._top = sidebar_rect.bottom - self.BUTTON_SIZE - self.PADDING
+
+        # Container rect defines the outer box drawn around the buttons
+        width_buttons = self.BUTTON_SIZE * len(self.SIZES) + self.PADDING * (len(self.SIZES) - 1)
+        width_shapes = self.BUTTON_SIZE * len(self.SHAPES) + self.PADDING * (len(self.SHAPES) - 1)
+        container_width = max(width_buttons, width_shapes) + self.PADDING * 2
+        container_height = self.BUTTON_SIZE * 2 + self.PADDING * 3
+        self.container_rect = pygame.Rect(sidebar_rect.left + self.PADDING, sidebar_rect.top, container_width, container_height)
+
+        # Button coordinates relative to the container
+        self._left = self.container_rect.left + self.PADDING
+        self._top = self.container_rect.top + self.PADDING
 
     def resize(self, sidebar_rect: pygame.Rect) -> None:
         """Update sidebar reference when resized."""
         self.sidebar_rect = sidebar_rect
-        self._top = sidebar_rect.bottom - self.BUTTON_SIZE - self.PADDING
+        width_buttons = self.BUTTON_SIZE * len(self.SIZES) + self.PADDING * (len(self.SIZES) - 1)
+        width_shapes = self.BUTTON_SIZE * len(self.SHAPES) + self.PADDING * (len(self.SHAPES) - 1)
+        self.container_rect.width = max(width_buttons, width_shapes) + self.PADDING * 2
+        self.container_rect.height = self.BUTTON_SIZE * 2 + self.PADDING * 3
+        self.container_rect.left = sidebar_rect.left + self.PADDING
 
     def set_top(self, top: int) -> None:
         """Set the top y-coordinate for the brush buttons."""
+        self.container_rect.top = top - self.PADDING
         self._top = top
+        self._left = self.container_rect.left + self.PADDING
+
+    def set_container(self, rect: pygame.Rect) -> None:
+        """Define the container rectangle for the brush."""
+        self.container_rect = rect
+        self._left = rect.left + self.PADDING
+        self._top = rect.top + self.PADDING
 
     def _button_rects(self) -> list[pygame.Rect]:
         rects = []
-        x = self.sidebar_rect.left + self.PADDING
+        x = self._left
         y = self._top
         for _ in self.SIZES:
             rects.append(pygame.Rect(x, y, self.BUTTON_SIZE, self.BUTTON_SIZE))
@@ -60,7 +82,7 @@ class TilesetBrush:
 
     def _shape_rects(self) -> list[pygame.Rect]:
         rects = []
-        x = self.sidebar_rect.left + self.PADDING
+        x = self._left
         y = self._top + self.BUTTON_SIZE + self.PADDING
         for _ in self.SHAPES:
             rects.append(pygame.Rect(x, y, self.BUTTON_SIZE, self.BUTTON_SIZE))
@@ -70,6 +92,8 @@ class TilesetBrush:
     def handle_event(self, event: pygame.event.Event) -> None:
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             mx, my = event.pos
+            if not self.container_rect.collidepoint(mx, my):
+                return
             for size, rect in zip(self.SIZES, self._button_rects()):
                 if rect.collidepoint(mx, my):
                     self.selected = size
@@ -80,6 +104,8 @@ class TilesetBrush:
                     return
 
     def draw(self, surface: pygame.Surface) -> None:
+        pygame.draw.rect(surface, DARK_GRAY, self.container_rect)
+        pygame.draw.rect(surface, SIDEBAR_BORDER, self.container_rect, 1)
         for size, rect in zip(self.SIZES, self._button_rects()):
             color = LIGHT_GRAY if size == self.selected else DARK_GRAY
             pygame.draw.rect(surface, color, rect)


### PR DESCRIPTION
## Summary
- wrap layer management UI in a container
- allow mouse wheel scrolling through layers
- add bordered container for brush UI
- update tab manager to position brush and layer containers
- make brush/layer boxes share sidebar width and stop scrolling when not needed
- limit layer box height
- move layer add/delete buttons to the side of the list

## Testing
- `python -m py_compile editor_app.py game_core/editor/sidebar/sidebar_tab_manager.py game_core/editor/tileset_tab/tileset_layer.py game_core/editor/tileset_tab/tileset_brush.py`


------
https://chatgpt.com/codex/tasks/task_e_684402e88788832d851ef7804c449bc4